### PR TITLE
Implement Poseidon2 Chip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "derive",
     "machine",
     "memory",
+    "poseidon2",
     "prover",
     "util",
     "verifier"

--- a/alu_u32/src/add/mod.rs
+++ b/alu_u32/src/add/mod.rs
@@ -69,7 +69,7 @@ impl Add32Chip {
         M: MachineWithAdd32Chip<F = F>,
     {
         let mut row = [F::ZERO; NUM_ADD_COLS];
-        let mut cols: &mut Add32Cols<F> = unsafe { transmute(&mut row) };
+        let cols: &mut Add32Cols<F> = unsafe { transmute(&mut row) };
 
         match op {
             Operation::Add32(a, b, c) => {

--- a/alu_u32/src/add/stark.rs
+++ b/alu_u32/src/add/stark.rs
@@ -14,22 +14,22 @@ impl<AB: PermutationAirBuilder<F = B>, B: PrimeField> Air<AB> for Add32Stark {
         let main = builder.main();
         let local: &Add32Cols<AB::Var> = main.row(0).borrow();
 
-        let base = AB::Exp::from(AB::F::from_canonical_u32(1 << 8));
+        let base = AB::Expr::from(AB::F::from_canonical_u32(1 << 8));
 
         let carry_0 = local.input_1[3] + local.input_2[3] - local.output[3];
         let carry_1 = local.input_1[2] + local.input_2[2] + carry_0.clone() - local.output[2];
         let carry_2 = local.input_1[1] + local.input_2[1] + carry_1.clone() - local.output[1];
         let carry_3 = local.input_1[0] + local.input_2[0] + carry_2.clone() - local.output[0];
 
-        builder.assert_zero(carry_0.clone() * (base.clone() + carry_0.clone()));
-        builder.assert_zero(carry_1.clone() * (base.clone() + carry_1.clone()));
-        builder.assert_zero(carry_2.clone() * (base.clone() + carry_2.clone()));
-        builder.assert_zero(carry_3.clone() * (base.clone() + carry_3.clone()));
+        builder.assert_zero(carry_0.clone() * (base.clone() + carry_0));
+        builder.assert_zero(carry_1.clone() * (base.clone() + carry_1));
+        builder.assert_zero(carry_2.clone() * (base.clone() + carry_2));
+        builder.assert_zero(carry_3.clone() * (base + carry_3));
 
         // Bus opcode constraint
         builder.assert_eq(
             local.opcode,
-            AB::Exp::from(AB::F::from_canonical_u32(Add32Opcode)),
+            AB::Expr::from(AB::F::from_canonical_u32(Add32Opcode)),
         );
 
         // TODO: Range check output ([0,256]) using preprocessed lookup table

--- a/alu_u32/src/mul/mod.rs
+++ b/alu_u32/src/mul/mod.rs
@@ -74,7 +74,7 @@ impl Mul32Chip {
         M: MachineWithMul32Chip<F = F>,
     {
         let mut row = [F::ZERO; NUM_MUL_COLS];
-        let mut cols: &mut Mul32Cols<F> = unsafe { transmute(&mut row) };
+        let cols: &mut Mul32Cols<F> = unsafe { transmute(&mut row) };
 
         match op {
             Operation::Mul32(a, b, c) => {
@@ -112,11 +112,11 @@ where
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true).into()
+            state.mem_mut().read(clk, read_addr_2, true)
         };
 
         let a = b * c;
-        state.mem_mut().write(clk, write_addr, a.into(), true);
+        state.mem_mut().write(clk, write_addr, a, true);
 
         state
             .mul_u32_mut()

--- a/alu_u32/src/mul/stark.rs
+++ b/alu_u32/src/mul/stark.rs
@@ -19,10 +19,8 @@ impl<AB: PermutationAirBuilder<F = B>, B: PrimeField> Air<AB> for Mul32Stark {
         let next: &Mul32Cols<AB::Var> = main.row(1).borrow();
 
         // Limb weights modulo 2^32
-        let mut base_m: [AB::Exp; 4] = unsafe { MaybeUninit::uninit().assume_init() };
-        for (i, b) in [1 << 24, 1 << 16, 1 << 8, 1].into_iter().enumerate() {
-            base_m[i] = AB::Exp::from(AB::F::from_canonical_u32(b));
-        }
+        let base_m = [1 << 24, 1 << 16, 1 << 8, 1 << 0]
+            .map(|b| AB::Expr::from(AB::F::from_canonical_u32(b)));
 
         // Partially reduced summation of input product limbs (mod 2^32)
         let pi = pi_m::<4, AB>(&base_m, local.input_1, local.input_2);
@@ -37,35 +35,35 @@ impl<AB: PermutationAirBuilder<F = B>, B: PrimeField> Air<AB> for Mul32Stark {
         let sigma_prime = sigma_m::<2, AB>(&base_m[..2], local.output);
 
         // Congruence checks
-        builder.assert_eq(pi - sigma, local.r * AB::Exp::from(AB::F::TWO));
+        builder.assert_eq(pi - sigma, local.r * AB::Expr::from(AB::F::TWO));
         builder.assert_eq(pi_prime - sigma_prime, local.s * base_m[1].clone());
 
         // Range check counter
         builder
             .when_first_row()
-            .assert_eq(local.counter, AB::Exp::from(AB::F::ONE));
+            .assert_eq(local.counter, AB::Expr::from(AB::F::ONE));
         builder.when_transition().assert_zero(
             (local.counter - next.counter)
-                * (local.counter + AB::Exp::from(AB::F::ONE) - next.counter),
+                * (local.counter + AB::Expr::from(AB::F::ONE) - next.counter),
         );
         builder.when_last_row().assert_eq(
             local.counter,
-            AB::Exp::from(AB::F::from_canonical_u32(1 << 10)),
+            AB::Expr::from(AB::F::from_canonical_u32(1 << 10)),
         );
 
         // Bus opcode constraint
         builder.assert_eq(
             local.opcode,
-            AB::Exp::from(AB::F::from_canonical_u32(Mul32Opcode)),
+            AB::Expr::from(AB::F::from_canonical_u32(Mul32Opcode)),
         );
     }
 }
 
 fn pi_m<const N: usize, AB: PermutationAirBuilder>(
-    base: &[AB::Exp],
+    base: &[AB::Expr],
     input_1: Word<AB::Var>,
     input_2: Word<AB::Var>,
-) -> AB::Exp {
+) -> AB::Expr {
     iproduct!(0..N, 0..N)
         .filter(|(i, j)| i + j < N)
         .map(|(i, j)| base[i + j].clone() * input_1[i] * input_2[j])
@@ -73,9 +71,9 @@ fn pi_m<const N: usize, AB: PermutationAirBuilder>(
 }
 
 fn sigma_m<const N: usize, AB: PermutationAirBuilder>(
-    base: &[AB::Exp],
+    base: &[AB::Expr],
     input: Word<AB::Var>,
-) -> AB::Exp {
+) -> AB::Expr {
     input
         .into_iter()
         .enumerate()

--- a/alu_u32/src/sub/mod.rs
+++ b/alu_u32/src/sub/mod.rs
@@ -68,7 +68,7 @@ impl Sub32Chip {
         M: MachineWithSub32Chip<F = F>,
     {
         let mut row = [F::ZERO; NUM_SUB_COLS];
-        let mut cols: &mut Sub32Cols<F> = unsafe { transmute(&mut row) };
+        let cols: &mut Sub32Cols<F> = unsafe { transmute(&mut row) };
 
         match op {
             Operation::Sub32(a, b, c) => {

--- a/alu_u32/src/sub/stark.rs
+++ b/alu_u32/src/sub/stark.rs
@@ -13,7 +13,7 @@ impl<AB: PermutationAirBuilder<F = B>, B: PrimeField> Air<AB> for Sub32Stark {
         let main = builder.main();
         let local: &Sub32Cols<AB::Var> = main.row(0).borrow();
 
-        let base = AB::Exp::from(AB::F::from_canonical_u32(1 << 8));
+        let base = AB::Expr::from(AB::F::from_canonical_u32(1 << 8));
 
         let sub_0 = local.input_1[3] - local.input_2[3];
         let sub_1 = local.input_1[2] - local.input_2[2];
@@ -28,21 +28,21 @@ impl<AB: PermutationAirBuilder<F = B>, B: PrimeField> Air<AB> for Sub32Stark {
         // First byte
         builder.assert_zero(borrow_0.clone() * (base.clone() - sub_0 - local.output[3]));
         builder
-            .assert_zero(borrow_0 * (sub_1.clone() - local.output[2] - AB::Exp::from(AB::F::ONE)));
+            .assert_zero(borrow_0 * (sub_1.clone() - local.output[2] - AB::Expr::from(AB::F::ONE)));
 
         // Second byte
         builder.assert_zero(borrow_1.clone() * (base.clone() - sub_1 - local.output[2]));
         builder
-            .assert_zero(borrow_1 * (sub_2.clone() - local.output[1] - AB::Exp::from(AB::F::ONE)));
+            .assert_zero(borrow_1 * (sub_2.clone() - local.output[1] - AB::Expr::from(AB::F::ONE)));
 
         // Third byte
-        builder.assert_zero(borrow_2.clone() * (base.clone() - sub_2 - local.output[1]));
-        builder.assert_zero(borrow_2 * (sub_3 - local.output[0] - AB::Exp::from(AB::F::ONE)));
+        builder.assert_zero(borrow_2.clone() * (base - sub_2 - local.output[1]));
+        builder.assert_zero(borrow_2 * (sub_3 - local.output[0] - AB::Expr::from(AB::F::ONE)));
 
         // Bus opcode constraint
         builder.assert_eq(
             local.opcode,
-            AB::Exp::from(AB::F::from_canonical_u32(Sub32Opcode)),
+            AB::Expr::from(AB::F::from_canonical_u32(Sub32Opcode)),
         );
 
         todo!()

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -86,8 +86,7 @@ where
             CPU_COL_INDICES
                 .mem_channels
                 .iter()
-                .map(|c| c.value.into_iter().map(VirtualPairCol::single_main))
-                .flatten()
+                .flat_map(|c| c.value.into_iter().map(VirtualPairCol::single_main))
                 .collect::<Vec<_>>(),
         );
         fields.push(VirtualPairCol::single_main(

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -56,7 +56,7 @@ where
             .operations
             .par_iter()
             .enumerate()
-            .map(|(n, op)| self.op_to_row(n, &op, machine))
+            .map(|(n, op)| self.op_to_row(n, op, machine))
             .collect::<Vec<_>>();
         RowMajorMatrix::new(rows.concat(), NUM_CPU_COLS)
     }
@@ -103,7 +103,7 @@ impl CpuChip {
         M: MachineWithMemoryChip,
     {
         let mut row = [F::ZERO; NUM_CPU_COLS];
-        let mut cols: &mut CpuCols<F> = unsafe { transmute(&mut row) };
+        let cols: &mut CpuCols<F> = unsafe { transmute(&mut row) };
 
         cols.pc = F::from_canonical_u32(self.registers[clk].pc);
         cols.fp = F::from_canonical_u32(self.registers[clk].fp);
@@ -368,7 +368,7 @@ where
         let clk = state.cpu().clock;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
         let value = Word([ops.b() as u8, ops.c() as u8, ops.d() as u8, ops.e() as u8]);
-        state.mem_mut().write(clk, write_addr, value.into(), true);
+        state.mem_mut().write(clk, write_addr, value, true);
         state.cpu_mut().pc += 1;
         state.cpu_mut().clock += 1;
         state.cpu_mut().operations.push(Operation::Imm32);

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -79,20 +79,13 @@ impl CpuStark {
 
         // Read (1)
         builder
-            .when(is_jalv + is_beq + is_bne + is_bus_op.clone())
+            .when(is_jalv + is_beq + is_bne + is_bus_op)
             .assert_eq(local.read_addr_1(), addr_b.clone());
         builder
-            .when(is_load.clone() + is_store.clone())
+            .when(is_load + is_store)
             .assert_eq(local.read_addr_1(), addr_c.clone());
         builder
-            .when(
-                is_load.clone()
-                    + is_store.clone()
-                    + is_jalv.clone()
-                    + is_beq.clone()
-                    + is_bne.clone()
-                    + is_bus_op.clone(),
-            )
+            .when(is_load + is_store + is_jalv + is_beq + is_bne + is_bus_op)
             .assert_one(local.read_1_used());
 
         // Read (2)
@@ -107,43 +100,33 @@ impl CpuStark {
             .assert_eq(local.read_addr_2(), addr_c);
         builder
             .when(
-                is_store.clone()
-                    + is_load.clone()
-                    + is_jalv.clone()
-                    + is_beq.clone()
-                    + is_bne.clone()
-                    + (AB::Expr::from(AB::F::ONE) - is_imm_op) * is_bus_op.clone(),
+                is_store
+                    + is_load
+                    + is_jalv
+                    + is_beq
+                    + is_bne
+                    + (AB::Expr::from(AB::F::ONE) - is_imm_op) * is_bus_op,
             )
             .assert_one(local.read_2_used());
 
         // Write
         builder
-            .when(
-                is_load.clone()
-                    + is_jal.clone()
-                    + is_jalv.clone()
-                    + is_imm32.clone()
-                    + is_bus_op.clone(),
-            )
+            .when(is_load + is_jal + is_jalv + is_imm32 + is_bus_op)
             .assert_eq(local.write_addr(), addr_a);
-        builder
-            .when(is_store.clone())
-            .assert_eq(local.write_addr(), addr_b);
-        builder
-            .when(is_load.clone() + is_store.clone())
-            .assert_zero(
-                local
-                    .read_value_2()
-                    .into_iter()
-                    .zip(local.write_value())
-                    .map(|(a, b)| (a - b) * (a - b))
-                    .sum::<AB::Expr>(),
-            );
+        builder.when(is_store).assert_eq(local.write_addr(), addr_b);
+        builder.when(is_load + is_store).assert_zero(
+            local
+                .read_value_2()
+                .into_iter()
+                .zip(local.write_value())
+                .map(|(a, b)| (a - b) * (a - b))
+                .sum::<AB::Expr>(),
+        );
         builder
             .when_transition()
-            .when(is_jal.clone() + is_jalv.clone())
+            .when(is_jal + is_jalv)
             .assert_eq(next.pc, reduce::<F, AB>(base, local.write_value()));
-        builder.when(is_imm32.clone()).assert_zero(
+        builder.when(is_imm32).assert_zero(
             local
                 .write_value()
                 .into_iter()
@@ -152,14 +135,7 @@ impl CpuStark {
                 .sum::<AB::Expr>(),
         );
         builder
-            .when(
-                is_store.clone()
-                    + is_load.clone()
-                    + is_jal.clone()
-                    + is_jalv.clone()
-                    + is_imm32.clone()
-                    + is_bus_op.clone(),
-            )
+            .when(is_store + is_load + is_jal + is_jalv + is_imm32 + is_bus_op)
             .assert_one(local.write_used());
     }
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -186,7 +186,7 @@ pub fn aligned_borrow_derive(input: TokenStream) -> TokenStream {
     // Get struct name from ast
     let name = &ast.ident;
     let methods = quote! {
-        impl<T> Borrow<#name<T>> for [T] {
+        impl<T> core::borrow::Borrow<#name<T>> for [T] {
             fn borrow(&self) -> &#name<T> {
                 // TODO: Double check if this is correct & consider making asserts debug-only.
                 let (prefix, shorts, _suffix) = unsafe { self.align_to::<#name<T>>() };
@@ -196,7 +196,7 @@ pub fn aligned_borrow_derive(input: TokenStream) -> TokenStream {
             }
         }
 
-        impl<T> BorrowMut<#name<T>> for [T] {
+        impl<T> core::borrow::BorrowMut<#name<T>> for [T] {
             fn borrow_mut(&mut self) -> &mut #name<T> {
                 // TODO: Double check if this is correct & consider making asserts debug-only.
                 let (prefix, shorts, _suffix) = unsafe { self.align_to_mut::<#name<T>>() };

--- a/machine/src/core.rs
+++ b/machine/src/core.rs
@@ -22,17 +22,17 @@ impl<F: PrimeField> Word<F> {
     pub fn reduce(self) -> F {
         let mut result = F::ZERO;
         for (n, item) in self.0.into_iter().rev().enumerate() {
-            result = result + item * F::from_canonical_u32(1 << 8 * n);
+            result += item * F::from_canonical_u32(1 << (8 * n));
         }
         result
     }
 }
 
-impl Into<u32> for Word<u8> {
-    fn into(self) -> u32 {
+impl From<Word<u8>> for u32 {
+    fn from(word: Word<u8>) -> Self {
         let mut result = 0u32;
         for i in 0..MEMORY_CELL_BYTES {
-            result += (self[MEMORY_CELL_BYTES - i - 1] as u32) << (i * 8);
+            result += (word[MEMORY_CELL_BYTES - i - 1] as u32) << (i * 8);
         }
         result
     }

--- a/machine/src/core.rs
+++ b/machine/src/core.rs
@@ -1,6 +1,7 @@
 use super::{Field, PrimeField, PrimeField64, MEMORY_CELL_BYTES};
 use core::ops::{Add, Index, IndexMut, Mul, Sub};
 
+/// Big-Endian Word
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Word<F>(pub [F; MEMORY_CELL_BYTES]);
 

--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -69,7 +69,7 @@ impl<F: PrimeField> Operands<F> {
     pub fn from_i32_slice(slice: &[i32]) -> Self {
         let mut operands = [F::ZERO; 5];
         for (i, &operand) in slice.iter().enumerate() {
-            let abs = F::from_canonical_u32(operand.abs() as u32);
+            let abs = F::from_canonical_u32(operand.unsigned_abs());
             operands[i] = if operand < 0 { -abs } else { abs };
         }
         Self(operands)

--- a/machine/src/lookup.rs
+++ b/machine/src/lookup.rs
@@ -158,7 +158,7 @@ impl<const N: usize, const M: usize> LogUp<N, M> {
                 row[0] = running_sum[n];
                 row[1] = multiplicities[0][n];
             }
-            return RowMajorMatrix::new(values, 2);
+            RowMajorMatrix::new(values, 2)
         } else if N == 2 {
             let mut values = vec![F::ZERO; main.height() * 3];
             for (n, row) in values.chunks_mut(3).enumerate() {
@@ -166,9 +166,9 @@ impl<const N: usize, const M: usize> LogUp<N, M> {
                 row[1] = multiplicities[0][n];
                 row[2] = looking_inv[0][n];
             }
-            return RowMajorMatrix::new(values, 3);
+            RowMajorMatrix::new(values, 3)
         } else {
-            panic!("Unreachable");
+            panic!("Unreachable")
         }
     }
 
@@ -195,7 +195,7 @@ impl<const N: usize, const M: usize> LogUp<N, M> {
 
         // Running sum constraints
         let mut lhs = perm_next[0] - perm_local[0];
-        let mut rhs = AB::Exp::from(AB::F::ZERO);
+        let mut rhs = AB::Expr::from(AB::F::ZERO);
         let m_0 = perm_local[1];
         let alpha = rand_elems[0].clone();
         if N == 1 {
@@ -203,14 +203,14 @@ impl<const N: usize, const M: usize> LogUp<N, M> {
             let t_0 = main_local[lookups[0].1]; // Looked
 
             lhs *= (f_0 + alpha.clone()) * (t_0 + alpha.clone());
-            rhs += t_0 + alpha.clone() - m_0 * (f_0 + alpha.clone());
+            rhs += t_0 + alpha.clone() - m_0 * (f_0 + alpha);
         } else if N == 2 {
             // This assumes that the looked columns are the same
             let q_0 = perm_local[2];
             let t_0 = main_local[lookups[0].1];
 
             lhs *= t_0 + alpha.clone();
-            rhs += m_0 + q_0 * (t_0 + alpha.clone());
+            rhs += m_0 + q_0 * (t_0 + alpha);
         }
         builder.when_transition().assert_eq(lhs, rhs);
         builder.when_first_row().assert_zero(perm_local[0]);
@@ -242,16 +242,16 @@ pub fn batch_invert<F: Field>(cols: &[Vec<F>]) -> Vec<Vec<F>> {
     res
 }
 
-fn count_elements<F: PrimeField>(v1: &Vec<F>, v2: &Vec<F>) -> Vec<F> {
+fn count_elements<F: PrimeField>(v1: &[F], v2: &[F]) -> Vec<F> {
     let mut map: BTreeMap<F, F> = BTreeMap::new();
 
     // Count elements in the first vector
-    for &item in v1.iter() {
+    for &item in v1 {
         *map.entry(item).or_insert(F::ZERO) += F::ONE;
     }
 
     // Construct the final vector
-    v2.into_iter()
-        .map(|item| *map.get(&item).unwrap_or(&F::ZERO))
+    v2.iter()
+        .map(|item| *map.get(item).unwrap_or(&F::ZERO))
         .collect()
 }

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -63,12 +63,12 @@ impl MemoryChip {
     }
 
     pub fn read(&mut self, clk: u32, address: u32, log: bool) -> Word<u8> {
-        let value = self.cells.get(&address.into()).copied().unwrap();
+        let value = self.cells.get(&address).copied().unwrap();
         if log {
             self.operations
                 .entry(clk)
                 .or_insert_with(Vec::new)
-                .push(Operation::Read(address.into(), value));
+                .push(Operation::Read(address, value));
         }
         value
     }
@@ -80,7 +80,7 @@ impl MemoryChip {
                 .or_insert_with(Vec::new)
                 .push(Operation::Write(address, value));
         }
-        self.cells.insert(address, value.into());
+        self.cells.insert(address, value);
     }
 }
 
@@ -143,7 +143,7 @@ impl MemoryChip {
         op: Operation,
     ) -> [M::F; NUM_MEM_COLS] {
         let mut row = [F::ZERO; NUM_MEM_COLS];
-        let mut cols: &mut MemoryCols<F> = unsafe { transmute(&mut row) };
+        let cols: &mut MemoryCols<F> = unsafe { transmute(&mut row) };
 
         cols.clk = F::from_canonical_usize(clk);
         cols.counter = F::from_canonical_usize(n);
@@ -177,7 +177,7 @@ impl MemoryChip {
             if addr_diff != 0 {
                 continue;
             }
-            let clk_diff = (op2.0 - op1.0) as u32;
+            let clk_diff = op2.0 - op1.0;
             if clk_diff > table_len {
                 let num_dummy_ops = clk_diff / table_len;
                 for j in 0..num_dummy_ops {

--- a/memory/src/stark.rs
+++ b/memory/src/stark.rs
@@ -33,14 +33,14 @@ impl MemoryStark {
             .assert_eq(next.diff, next.addr - local.addr);
         builder
             .when_transition()
-            .when_ne(local.addr_not_equal, AB::Exp::from(AB::F::ONE))
-            .assert_eq(next.diff, next.clk - local.clk - AB::Exp::from(AB::F::ONE));
+            .when_ne(local.addr_not_equal, AB::Expr::from(AB::F::ONE))
+            .assert_eq(next.diff, next.clk - local.clk - AB::Expr::from(AB::F::ONE));
 
         // Read/write
         // TODO: Record \sum_i (value'_i - value_i)^2 in trace and convert to a single constraint?
         for (value_next, value) in next.value.into_iter().zip(local.value.into_iter()) {
             let is_value_unchanged =
-                (local.addr - next.addr + AB::Exp::from(AB::F::ONE)) * (value_next - value);
+                (local.addr - next.addr + AB::Expr::from(AB::F::ONE)) * (value_next - value);
             builder
                 .when_transition()
                 .when(next.is_read)
@@ -50,6 +50,6 @@ impl MemoryStark {
         // Counter
         builder
             .when_transition()
-            .assert_eq(next.counter, local.counter + AB::Exp::from(AB::F::ONE));
+            .assert_eq(next.counter, local.counter + AB::Expr::from(AB::F::ONE));
     }
 }

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "valida-poseidon2"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+itertools = "0.10.5"
+
+p3-air = { path = "../../Plonky3/air" }
+p3-field = { path = "../../Plonky3/field" }
+p3-matrix = { path = "../../Plonky3/matrix" }
+p3-mersenne-31 = { path = "../../Plonky3/mersenne-31" }
+p3-maybe-rayon = { path = "../../Plonky3/maybe-rayon" }
+
+valida-bus = { path = "../bus" }
+valida-derive = { path = "../derive" }
+valida-machine = { path = "../machine" }
+valida-memory = { path = "../memory" }
+valida-cpu = { path = "../cpu" }
+valida-util = { path = "../util" }

--- a/poseidon2/src/columns.rs
+++ b/poseidon2/src/columns.rs
@@ -1,0 +1,24 @@
+//! Posiedon2 STARK Columns
+
+use valida_derive::AlignedBorrow;
+use valida_util::indices_arr;
+
+/// Columns
+#[repr(C)]
+#[derive(AlignedBorrow, Default)]
+pub struct Columns<T> {
+    
+}
+
+/// Number of Columns
+pub const NUM_COLUMNS = size_of::<Columns<u8>>(); 
+
+/// Column Indices
+pub const COLUMN_INDICES: Columns<usize> = make_column_map();
+
+/// Builds the column map from the index array.
+#[inline]
+const fn make_column_map() -> Columns<usize> {
+    let indices = indices_arr::<NUM_COLUMNS>();
+    unsafe { transmute::<[usize; NUM_COLUMNS], Columns<usize>>(indices) }
+}

--- a/poseidon2/src/columns.rs
+++ b/poseidon2/src/columns.rs
@@ -4,21 +4,175 @@ use crate::Config;
 use valida_derive::AlignedBorrow;
 use valida_util::indices_arr;
 
-/// Poseidon2 Columns
+/// Columns for Single-Row Poseidon2 STARK
+///
+/// The columns of the STARK are divided into two parts: state registers and S-BOX registers.
+/// Because the matrix multiplications are linear functions, we don't need auxiliary registers for
+/// the intermediate values.
+///
+/// As an example, let's consider a `WIDTH = 3` and `SBOX_DEGREE = 5` instance.
+///
+/// |  0 |  1 |  2 |         3 |         4 |         5 |         6 |         7 |         8 |
+/// |----|----|----|-----------|-----------|-----------|-----------|-----------|-----------|
+/// | s0 | s1 | s2 | (s0+r0)^3 | (s1+r1)^3 | (s2+r2)^3 | (s0+r0)^5 | (s1+r1)^5 | (s2+r2)^5 |
+///
+/// Because the S-BOX is a quintic function but we only have degree 3 constraints, we split the
+/// computation into the first degree 3 part and then the second degree 2 part. After this part,
+/// we import the right most columns into the matrix multiplication which write to the next state
+/// section. Each section has `WIDTH`-many state columns
 #[repr(C)]
-#[derive(AlignedBorrow, Default)]
-pub struct Columns<C, T>
-where
-    C: Config,
-{
-    ///
-    pub sbox: SBox<T>,
+pub struct Columns<
+    T,
+    const WIDTH: usize,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+> {
+    /// Beginning Full Rounds
+    pub beginning_full_rounds: [FullRound<T, WIDTH, SBOX_REGISTERS>; HALF_FULL_ROUNDS],
+
+    /// Partial Rounds
+    pub partial_rounds: [PartialRound<T, WIDTH, SBOX_REGISTERS>; PARTIAL_ROUNDS],
+
+    /// Ending Full Rounds
+    pub ending_full_rounds: [FullRound<T, WIDTH, SBOX_REGISTERS>; HALF_FULL_ROUNDS],
 }
 
-///
-pub struct SBox<T> {}
+impl<
+        T,
+        const WIDTH: usize,
+        const SBOX_REGISTERS: usize,
+        const HALF_FULL_ROUNDS: usize,
+        const PARTIAL_ROUNDS: usize,
+    > Columns<T, WIDTH, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+{
+    #[inline]
+    fn eval<AB>(
+        &self,
+        initial_state: [AB::F; WIDTH],
+        beginning_full_round_constants: &[[AB::F; WIDTH]; HALF_FULL_ROUNDS],
+        partial_round_constants: &[AB::F; PARTIAL_ROUNDS],
+        ending_full_round_constants: &[[AB::F; WIDTH]; HALF_FULL_ROUNDS],
+        builder: &mut AB,
+    ) -> [AB::F; WIDTH]
+    where
+        AB: AirBuilder,
+        AB::F: PrimeField,
+    {
+        let mut state = initial_state;
+        for round in 0..HALF_FULL_ROUNDS {
+            state = beginning_full_rounds[round].eval(
+                state,
+                &beginning_full_round_constants[round],
+                builder,
+            );
+        }
+        for round in 0..PARTIAL_ROUNDS {
+            state = partial_rounds[round].eval(state, &partial_round_constants[round], builder);
+        }
+        for round in 0..HALF_FULL_ROUNDS {
+            state =
+                ending_full_rounds[round].eval(state, &ending_full_round_constants[round], builder);
+        }
+        state
+    }
+}
 
-impl<C, T> Columns<C, T> where C: Config {}
+/// Full Round Columns
+#[repr(C)]
+pub struct FullRound<T, const WIDTH: usize, const SBOX_REGISTERS: usize> {
+    /// State Columns
+    pub state: [T; WIDTH],
+
+    /// S-BOX Columns
+    pub sbox: [SBox<T, SBOX_REGISTERS>; WIDTH],
+}
+
+impl<T, const WIDTH: usize, const SBOX_REGISTERS: usize> FullRound<T, WIDTH, SBOX_REGISTERS> {
+    ///
+    #[inline]
+    fn eval<AB>(
+        &self,
+        state: &[AB::F; WIDTH],
+        round_constants: &[AB::F; WIDTH],
+        builder: &mut AB,
+    ) -> [AB::F; WIDTH]
+    where
+        AB: AirBuilder,
+        AB::F: PrimeField,
+    {
+        for i in 0..WIDTH {
+            builder.assert_eq(state[0][i], self.state[0][i]);
+        }
+        for (i, (s, r)) in self.state.iter().zip(round_constants.iter()).enumerate() {
+            self.sbox[i].eval(s + r, builder);
+        }
+        // TODO: add matrix multiply
+        todo!()
+    }
+}
+
+/// Partial Round Columns
+#[repr(C)]
+pub struct PartialRound<T, const WIDTH: usize, const SBOX_REGISTERS: usize> {
+    /// State Columns
+    pub state: [T; WIDTH],
+
+    /// S-BOX Columns
+    pub sbox: SBox<T, SBOX_REGISTERS>,
+}
+
+impl<T, const WIDTH: usize, const SBOX_REGISTERS: usize> PartialRound<T, WIDTH, SBOX_REGISTERS> {
+    ///
+    #[inline]
+    fn eval<AB>(
+        &self,
+        state: &[AB::F; WIDTH],
+        round_constant: &AB::F,
+        builder: &mut AB,
+    ) -> [AB::F; WIDTH]
+    where
+        AB: AirBuilder,
+        AB::F: PrimeField,
+    {
+        for i in 0..WIDTH {
+            builder.assert_eq(state[0][i], self.state[0][i]);
+        }
+        self.sbox.eval(self.state[0] + round_constant, builder);
+        // TODO: add matrix multiply
+        todo!()
+    }
+}
+
+/// S-BOX Columns
+///
+/// Use this column-set for an S-BOX that can be computed in `REGISTERS`-many columns.
+#[repr(C)]
+pub struct SBox<T, const REGISTERS: usize>(pub [T; REGISTERS]);
+
+impl<T, const REGISTERS: usize> SBox<T, REGISTERS> {
+    /// Evaluates the S-BOX by multiplying successive squares of the base element `x` into the
+    /// running product, starting by cubing `x` and setting the first register to that value and
+    /// then squaring `x` and multiplying the previous register by that value and so on.
+    ///
+    /// # Efficiency Note
+    ///
+    /// This is not the most efficient use of these registers and for some powers we will use more
+    /// registers than necessary. In general we should compute the smallest addition chain for the
+    /// given S-BOX power.
+    #[inline]
+    pub fn eval<AB>(&self, x: &AB::F, builder: &mut AB) -> AB::F
+    where
+        AB: AirBuilder,
+        AB::F: PrimeField,
+    {
+        builder.assert_eq(self.0[0], cube(x));
+        for j in 1..SBOX_REGISTERS {
+            builder.assert_eq(self.0[j], self.0[j - 1] * x * x);
+        }
+        self.0[SBOX_REGISTERS - 1]
+    }
+}
 
 // TODO: Compute these constants
 //
@@ -38,3 +192,12 @@ impl<C, T> Columns<C, T> where C: Config {}
 //     let indices = indices_arr::<NUM_COLUMNS>();
 //     unsafe { transmute::<[usize; NUM_COLUMNS], Columns<C, usize>>(indices) }
 // }
+
+///
+#[inline]
+fn cube<F>(x: F) -> F
+where
+    F: PrimeField,
+{
+    x * x * x
+}

--- a/poseidon2/src/columns.rs
+++ b/poseidon2/src/columns.rs
@@ -92,7 +92,7 @@ where
         &self,
         state: &mut [AB::Expr; WIDTH],
         round: usize,
-        round_constants: &[AB::Expr; WIDTH],
+        round_constants: &[[AB::Expr; WIDTH]; HALF_FULL_ROUNDS],
         builder: &mut AB,
     ) where
         T: Copy,
@@ -107,7 +107,7 @@ where
         &self,
         state: &mut [AB::Expr; WIDTH],
         round: usize,
-        round_constants: &[AB::Expr; WIDTH],
+        round_constants: &[AB::Expr; PARTIAL_ROUNDS],
         internal_matrix_diagonal: &[AB::Expr; WIDTH],
         builder: &mut AB,
     ) where
@@ -128,7 +128,7 @@ where
         &self,
         state: &mut [AB::Expr; WIDTH],
         round: usize,
-        round_constants: &[AB::Expr; WIDTH],
+        round_constants: &[[AB::Expr; WIDTH]; HALF_FULL_ROUNDS],
         builder: &mut AB,
     ) where
         T: Copy,

--- a/poseidon2/src/columns.rs
+++ b/poseidon2/src/columns.rs
@@ -1,24 +1,40 @@
 //! Posiedon2 STARK Columns
 
+use crate::Config;
 use valida_derive::AlignedBorrow;
 use valida_util::indices_arr;
 
-/// Columns
+/// Poseidon2 Columns
 #[repr(C)]
 #[derive(AlignedBorrow, Default)]
-pub struct Columns<T> {
-    
+pub struct Columns<C, T>
+where
+    C: Config,
+{
+    ///
+    pub sbox: SBox<T>,
 }
 
-/// Number of Columns
-pub const NUM_COLUMNS = size_of::<Columns<u8>>(); 
+///
+pub struct SBox<T> {}
 
-/// Column Indices
-pub const COLUMN_INDICES: Columns<usize> = make_column_map();
+impl<C, T> Columns<C, T> where C: Config {}
 
-/// Builds the column map from the index array.
-#[inline]
-const fn make_column_map() -> Columns<usize> {
-    let indices = indices_arr::<NUM_COLUMNS>();
-    unsafe { transmute::<[usize; NUM_COLUMNS], Columns<usize>>(indices) }
-}
+// TODO: Compute these constants
+//
+// /// Number of Columns
+// pub const NUM_COLUMNS = size_of::<Columns<u8>>();
+//
+// /// Column Indices
+// pub const COLUMN_INDICES: Columns<usize> = make_column_map();
+//
+// /// Builds the column map from the index array.
+// #[inline]
+// const fn make_column_map<C>() -> Columns<C, usize>
+// where
+//     C: Config,
+// {
+//     const NUM_COLUMNS: usize = size_of::<Columns<C, u8>>();
+//     let indices = indices_arr::<NUM_COLUMNS>();
+//     unsafe { transmute::<[usize; NUM_COLUMNS], Columns<C, usize>>(indices) }
+// }

--- a/poseidon2/src/columns.rs
+++ b/poseidon2/src/columns.rs
@@ -26,52 +26,57 @@ use valida_util::indices_arr;
 pub struct Columns<
     T,
     const WIDTH: usize,
+    const SBOX_DEGREE: usize,
     const SBOX_REGISTERS: usize,
     const HALF_FULL_ROUNDS: usize,
     const PARTIAL_ROUNDS: usize,
 > {
     /// Beginning Full Rounds
-    pub beginning_full_rounds: [FullRound<T, WIDTH, SBOX_REGISTERS>; HALF_FULL_ROUNDS],
+    pub beginning_full_rounds: [FullRound<T, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>; HALF_FULL_ROUNDS],
 
     /// Partial Rounds
-    pub partial_rounds: [PartialRound<T, WIDTH, SBOX_REGISTERS>; PARTIAL_ROUNDS],
+    pub partial_rounds: [PartialRound<T, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>; PARTIAL_ROUNDS],
 
     /// Ending Full Rounds
-    pub ending_full_rounds: [FullRound<T, WIDTH, SBOX_REGISTERS>; HALF_FULL_ROUNDS],
+    pub ending_full_rounds: [FullRound<T, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>; HALF_FULL_ROUNDS],
 }
 
 impl<
         T,
         const WIDTH: usize,
+        const SBOX_DEGREE: usize,
         const SBOX_REGISTERS: usize,
         const HALF_FULL_ROUNDS: usize,
         const PARTIAL_ROUNDS: usize,
-    > Columns<T, WIDTH, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+    > Columns<T, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
+    ///
     #[inline]
-    fn eval<AB>(
+    pub fn eval<AB>(
         &self,
-        state: &mut [T; WIDTH],
+        state: &mut [AB::Expr; WIDTH],
         beginning_full_round_constants: &[[AB::Expr; WIDTH]; HALF_FULL_ROUNDS],
         partial_round_constants: &[AB::Expr; PARTIAL_ROUNDS],
         ending_full_round_constants: &[[AB::Expr; WIDTH]; HALF_FULL_ROUNDS],
         builder: &mut AB,
     ) where
+        T: Copy,
         AB: AirBuilder<Var = T>,
     {
+        // TODO: Add initial linear layer (matmul_external)
+        // matmul_external(state);
         for round in 0..HALF_FULL_ROUNDS {
-            *state = self.beginning_full_rounds[round].eval(
+            self.beginning_full_rounds[round].eval(
                 state,
                 &beginning_full_round_constants[round],
                 builder,
             );
         }
         for round in 0..PARTIAL_ROUNDS {
-            *state =
-                self.partial_rounds[round].eval(state, &partial_round_constants[round], builder);
+            self.partial_rounds[round].eval(state, &partial_round_constants[round], builder);
         }
         for round in 0..HALF_FULL_ROUNDS {
-            *state = self.ending_full_rounds[round].eval(
+            self.ending_full_rounds[round].eval(
                 state,
                 &ending_full_round_constants[round],
                 builder,
@@ -82,64 +87,63 @@ impl<
 
 /// Full Round Columns
 #[repr(C)]
-pub struct FullRound<T, const WIDTH: usize, const SBOX_REGISTERS: usize> {
-    /// State Columns
-    pub state: [T; WIDTH],
-
+pub struct FullRound<T, const WIDTH: usize, const SBOX_DEGREE: usize, const SBOX_REGISTERS: usize> {
     /// S-BOX Columns
-    pub sbox: [SBox<T, SBOX_REGISTERS>; WIDTH],
+    pub sbox: [SBox<T, SBOX_DEGREE, SBOX_REGISTERS>; WIDTH],
 }
 
-impl<T, const WIDTH: usize, const SBOX_REGISTERS: usize> FullRound<T, WIDTH, SBOX_REGISTERS> {
+impl<T, const WIDTH: usize, const SBOX_DEGREE: usize, const SBOX_REGISTERS: usize>
+    FullRound<T, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>
+{
     ///
     #[inline]
-    fn eval<AB>(
+    pub fn eval<AB>(
         &self,
-        state: &[T; WIDTH],
+        state: &mut [AB::Expr; WIDTH],
         round_constants: &[AB::Expr; WIDTH],
         builder: &mut AB,
-    ) -> [T; WIDTH]
-    where
+    ) where
+        T: Copy,
         AB: AirBuilder<Var = T>,
     {
-        // for i in 0..WIDTH {
-        //     builder.assert_eq(state[i], self.state[i]);
-        // }
-        // for (i, (s, r)) in self.state.iter().zip(round_constants.iter()).enumerate() {
-        //     self.sbox[i].eval(*s + *r, builder);
-        // }
+        for (i, (s, r)) in state.iter_mut().zip(round_constants.iter()).enumerate() {
+            *s += r.clone();
+            self.sbox[i].eval(s, builder);
+        }
         // TODO: add matrix multiply
+        // matmul_external(state);
         todo!()
     }
 }
 
 /// Partial Round Columns
 #[repr(C)]
-pub struct PartialRound<T, const WIDTH: usize, const SBOX_REGISTERS: usize> {
-    /// State Columns
-    pub state: [T; WIDTH],
-
+pub struct PartialRound<
+    T,
+    const WIDTH: usize,
+    const SBOX_DEGREE: usize,
+    const SBOX_REGISTERS: usize,
+> {
     /// S-BOX Columns
-    pub sbox: SBox<T, SBOX_REGISTERS>,
+    pub sbox: SBox<T, SBOX_DEGREE, SBOX_REGISTERS>,
 }
 
-impl<T, const WIDTH: usize, const SBOX_REGISTERS: usize> PartialRound<T, WIDTH, SBOX_REGISTERS> {
+impl<T, const WIDTH: usize, const SBOX_DEGREE: usize, const SBOX_REGISTERS: usize>
+    PartialRound<T, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>
+{
     ///
     #[inline]
-    fn eval<AB>(
+    pub fn eval<AB>(
         &self,
-        state: &[T; WIDTH],
+        state: &mut [AB::Expr; WIDTH],
         round_constant: &AB::Expr,
         builder: &mut AB,
-    ) -> [T; WIDTH]
-    where
+    ) where
+        T: Copy,
         AB: AirBuilder<Var = T>,
     {
-        // for i in 0..WIDTH {
-        //     builder.assert_eq(state[i], self.state[i]);
-        // }
-        // let state0 = self.sbox.eval(self.state[0] + round_constant, builder);
-
+        state[0] += round_constant.clone();
+        self.sbox.eval(&mut state[0], builder);
         // TODO: add matrix multiply
         todo!()
     }
@@ -147,32 +151,115 @@ impl<T, const WIDTH: usize, const SBOX_REGISTERS: usize> PartialRound<T, WIDTH, 
 
 /// S-BOX Columns
 ///
-/// Use this column-set for an S-BOX that can be computed in `REGISTERS`-many columns.
+/// Use this column-set for an S-BOX that can be computed in `REGISTERS`-many columns. The S-BOX is
+/// checked to ensure that `REGISTERS` is the optimal number of registers for the given `DEGREE`
+/// for the degrees given in the Poseidon2 paper: `3`, `5`, `7`, and `11`. See [`Self::eval`] for
+/// more information.
 #[repr(C)]
-pub struct SBox<T, const REGISTERS: usize>(pub [T; REGISTERS]);
+pub struct SBox<T, const DEGREE: usize, const REGISTERS: usize>(pub [T; REGISTERS]);
 
-impl<T, const REGISTERS: usize> SBox<T, REGISTERS> {
-    /// Evaluates the S-BOX by multiplying successive squares of the base element `x` into the
-    /// running product, starting by cubing `x` and setting the first register to that value and
-    /// then squaring `x` and multiplying the previous register by that value and so on.
+impl<T, const DEGREE: usize, const REGISTERS: usize> SBox<T, DEGREE, REGISTERS> {
+    /// Degree-Register Table
+    ///
+    /// This table encodes the optimal number of S-BOX registers needed for the degree, where the
+    /// degree is the index into this table. A zero is placed for entries that are ignored.
+    pub const OPTIMAL_REGISTER_COUNT: [usize; 12] = [0, 0, 0, 1, 0, 2, 0, 3, 0, 0, 0, 3];
+
+    /// Evaluates the S-BOX over a degree-`1` expression `x`.
     ///
     /// # Efficiency Note
     ///
-    /// This is not the most efficient use of these registers and for some powers we will use more
-    /// registers than necessary. In general we should compute the smallest addition chain for the
-    /// given S-BOX power.
+    /// This method computes the S-BOX by computing the cube of `x` and then successively
+    /// multiplying the running sum by the cube of `x` until the last multiplication where we use
+    /// the appropriate power to reach the final product:
+    ///
+    /// ```text
+    /// (x^3) * (x^3) * ... * (x^k) where k = d mod 3
+    /// ```
+    ///
+    /// The intermediate powers are stored in the auxiliary column registers. To maximize the
+    /// efficiency of the registers we try to do three multiplications per round. This is not the
+    /// optimal number of multiplications for all possible degrees, but for the S-BOX powers we are
+    /// interested in for Poseidon2 (namely `3`, `5`, `7`, and `11`), we get the optimal number
+    /// with this algorithm with the following register table:
+    ///
+    /// | `DEGREE` | `REGISTERS` |
+    /// |:--------:|:-----------:|
+    /// | `3`      | `1`         |
+    /// | `5`      | `2`         |
+    /// | `7`      | `3`         |
+    /// | `11`     | `3`         |
+    ///
+    /// We record this table in [`Self::OPTIMAL_REGISTER_COUNT`]. This algorithm does not perform
+    /// optimally for all possible degrees but provides a reasonable solution in most cases.
     #[inline]
-    pub fn eval<AB>(&self, x: &AB::Expr, builder: &mut AB) -> T
+    pub fn eval<AB>(&self, x: &mut AB::Expr, builder: &mut AB)
     where
         T: Copy,
         AB: AirBuilder<Var = T>,
     {
-        builder.assert_eq(self.0[0], x.clone() * x.clone() * x.clone());
-        // for j in 1..REGISTERS {
-        //     builder.assert_eq(self.0[j], self.0[j - 1] * x * x);
-        // }
-        // self.0[REGISTERS - 1]
-        todo!()
+        assert_ne!(REGISTERS, 0, "The number of REGISTERS must be positive.");
+        assert!(
+            Self::is_unknown_or_optimal(),
+            "The number of REGISTERS must be optimal for the given DEGREE."
+        );
+        let x_squared = x.clone() * x.clone();
+        let x_cubed = x_squared.clone() * x.clone();
+        self.load(0, x_cubed.clone(), builder);
+        if REGISTERS == 1 {
+            *x = self.0[0].into();
+            return;
+        }
+        if ((DEGREE - (DEGREE % 3)) / 3) % 3 == 0 {
+            (1..REGISTERS - 1).for_each(|j| self.load_product(j, &[0, 0, j - 1], builder));
+        } else {
+            (1..REGISTERS - 1).for_each(|j| self.load_product(j, &[0, j - 1], builder));
+        }
+        self.load(
+            REGISTERS - 1,
+            [x_cubed, x.clone(), x_squared][DEGREE % 3].clone()
+                * AB::Expr::from(self.0[REGISTERS - 2]),
+            builder,
+        );
+        *x = self.0[REGISTERS - 1].into();
+    }
+
+    /// Returns `true` when the optimal `DEGREE` and `REGISTERS` are chosen correctly.
+    #[inline]
+    const fn is_unknown_or_optimal() -> bool {
+        if DEGREE > 11 {
+            return true;
+        }
+        let optimal_count = Self::OPTIMAL_REGISTER_COUNT[DEGREE];
+        optimal_count == REGISTERS || optimal_count == 0
+    }
+
+    /// Loads `value` into the `i`-th S-BOX register.
+    #[inline]
+    fn load<AB>(&self, i: usize, value: AB::Expr, builder: &mut AB)
+    where
+        T: Copy,
+        AB: AirBuilder<Var = T>,
+    {
+        builder.assert_eq(AB::Expr::from(self.0[i]), value);
+    }
+
+    /// Loads the product over all `product` indices the into the `i`-th S-BOX register.
+    #[inline]
+    fn load_product<AB>(&self, i: usize, product: &[usize], builder: &mut AB)
+    where
+        T: Copy,
+        AB: AirBuilder<Var = T>,
+    {
+        assert!(
+            product.len() <= 3,
+            "Product is too big. We can only compute at most degree-3 constraints."
+        );
+        self.load(
+            i,
+            product.iter().map(|j| AB::Expr::from(self.0[*j])).product(),
+            builder,
+        );
     }
 }
 

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -1,0 +1,483 @@
+//! Poseidon2 Chip
+//!
+//! Implementation of the Poseidon2 Permutation from <https://eprint.iacr.org/2023/323>.
+
+// TODO: Flatten the Round Constants in the Permutation
+
+#![no_std]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![forbid(rustdoc::broken_intra_doc_links)]
+#![forbid(missing_docs)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use p3_matrix::dense::RowMajorMatrix;
+use valida_machine::Interaction;
+
+/// Sealed Trait Module
+mod sealed {
+    /// Sealed Trait
+    pub trait Sealed {}
+}
+
+/// Poseidon2 Valid Width Sizes
+pub trait Width: sealed::Sealed {
+    /// Width of the Permutation
+    const WIDTH: usize;
+
+    /// Internal Matrix Diagonal Type
+    ///
+    /// This type is used by the `matmul_internal` function to define the diagonal of the internal
+    /// matrix.
+    type InternalMatrixDiagonal<F>;
+
+    /// Computes the external matrix multiplication for the Poseidon2 Permutation.
+    ///
+    /// # Unchecked Lengths
+    ///
+    /// This function does not check that the length of the `state` slice is equal to the
+    /// `WIDTH` constant. This should be checked by the caller.
+    fn matmul_external<F>(state: &mut [F]);
+
+    /// Computes the internal matrix multiplication for the Poseidon2 Permutation.
+    ///
+    /// # Unchecked Lengths
+    ///
+    /// This function does not check that the lengths of the `state` slice nor `diagonal` are
+    /// equal to the `WIDTH` constant. This should be checked by the caller.
+    fn matmul_internal<F>(state: &mut [F], diagonal: &Self::InternalMatrixDiagonal<F>);
+}
+
+/// Poseidon2 Width Constant
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct WIDTH<const T: u8>;
+
+impl<const T: u8> sealed::Sealed for WIDTH<T> {}
+
+impl Width for WIDTH<2> {
+    const WIDTH: usize = 2;
+
+    /// Fixed Internal Matrix
+    ///
+    /// For the `WIDTH = 2` case we use the `[[2, 1], [1, 3]]` matrix.
+    type InternalMatrixDiagonal<F> = ();
+
+    /// Computes the external matrix multiplication for the Poseidon2 Permutation using the
+    /// `circ(2, 1)` matrix.
+    #[inline]
+    fn matmul_external<F>(state: &mut [F]) {
+        // let mut sum = state[0];
+        // sum.add_assign(&state[1]);
+        // state[0].add_assign(&sum);
+        // state[1].add_assign(&sum);
+        todo!()
+    }
+
+    ///
+    #[inline]
+    fn matmul_internal<F>(state: &mut [F], _: &Self::InternalMatrixDiagonal<F>) {
+        // let mut sum = state[0];
+        // sum.add_assign(&state[1]);
+        // state[0].add_assign(&sum);
+        // state[1].double_in_place();
+        // state[1].add_assign(&sum);
+        todo!()
+    }
+}
+
+impl Width for WIDTH<3> {
+    const WIDTH: usize = 3;
+
+    /// Fixed Internal Matrix
+    ///
+    /// For the `WIDTH = 3` case we use the `[[2, 1, 1], [1, 2, 1], [1, 1, 3]]` matrix.
+    type InternalMatrixDiagonal<F> = ();
+
+    /// Computes the external matrix multiplication for the Poseidon2 Permutation using the
+    /// `circ(2, 1, 1)` matrix.
+    #[inline]
+    fn matmul_external<F>(state: &mut [F]) {
+        // let mut sum = state[0];
+        // sum.add_assign(&state[1]);
+        // sum.add_assign(&state[2]);
+        // state[0].add_assign(&sum);
+        // state[1].add_assign(&sum);
+        // state[2].add_assign(&sum);
+        todo!()
+    }
+
+    ///
+    #[inline]
+    fn matmul_internal<F>(state: &mut [F], _: &Self::InternalMatrixDiagonal<F>) {
+        // let mut sum = state[0];
+        // sum.add_assign(&state[1]);
+        // sum.add_assign(&state[2]);
+        // state[0].add_assign(&sum);
+        // state[1].add_assign(&sum);
+        // state[2].double_in_place();
+        // state[2].add_assign(&sum);
+        todo!()
+    }
+}
+
+macro_rules! define_multiple_of_four_widths {
+    ($($width:literal),+) => {
+        $(
+            impl Width for WIDTH<$width> {
+                const WIDTH: usize = $width;
+
+                type InternalMatrixDiagonal<F> = [F; $width];
+
+                ///
+                #[inline]
+                fn matmul_external<F>(state: &mut [F]) {
+                    // let t4 = $width / 4;
+                    // for i in 0..t4 {
+                    //     let start_index = i * 4;
+                    //     let mut t_0 = state[start_index];
+                    //     t_0.add_assign(&state[start_index + 1]);
+                    //     let mut t_1 = state[start_index + 2];
+                    //     t_1.add_assign(&state[start_index + 3]);
+                    //     let mut t_2 = state[start_index + 1];
+                    //     t_2.double_in_place();
+                    //     t_2.add_assign(&t_1);
+                    //     let mut t_3 = state[start_index + 3];
+                    //     t_3.double_in_place();
+                    //     t_3.add_assign(&t_0);
+                    //     let mut t_4 = t_1;
+                    //     t_4.double_in_place();
+                    //     t_4.double_in_place();
+                    //     t_4.add_assign(&t_3);
+                    //     let mut t_5 = t_0;
+                    //     t_5.double_in_place();
+                    //     t_5.double_in_place();
+                    //     t_5.add_assign(&t_2);
+                    //     let mut t_6 = t_3;
+                    //     t_6.add_assign(&t_5);
+                    //     let mut t_7 = t_2;
+                    //     t_7.add_assign(&t_4);
+                    //     state[start_index] = t_6;
+                    //     state[start_index + 1] = t_5;
+                    //     state[start_index + 2] = t_7;
+                    //     state[start_index + 3] = t_4;
+                    // }
+                    // let mut stored = [F::zero(); 4];
+                    // for l in 0..4 {
+                    //     stored[l] = state[l];
+                    //     for j in 1..t4 {
+                    //         stored[l].add_assign(&state[4 * j + l]);
+                    //     }
+                    // }
+                    // for i in 0..state.len() {
+                    //     state[i].add_assign(&stored[i % 4]);
+                    // }
+                    todo!()
+                }
+
+                ///
+                #[inline]
+                fn matmul_internal<F>(state: &mut [F], diagonal: &Self::InternalMatrixDiagonal<F>) {
+                    // let mut sum = state[0];
+                    // state.iter().skip(1).for_each(|s| sum.add_assign(s));
+                    // for i in 0..state.len() {
+                    //     state[i].mul_assign(&diagonal[i]);
+                    //     state[i].add_assign(&sum);
+                    // }
+                    todo!()
+                }
+            }
+        )+
+    };
+}
+
+define_multiple_of_four_widths!(4, 8, 12, 16, 20, 24);
+
+/// Poseidon2 Valid S-BOX Degrees
+pub trait SBoxDegree: sealed::Sealed {
+    ///
+    const SBOX_DEGREE: usize;
+
+    ///
+    fn sbox_pow<F>(value: &mut F);
+
+    ///
+    #[inline]
+    fn apply_sbox<F>(state: &mut [F]) {
+        state.iter_mut().for_each(Self::sbox_pow);
+    }
+}
+
+/// Poseidon2 S-BOX Degree Constant
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct SBOX_DEGREE<const T: u8>;
+
+impl<const T: u8> sealed::Sealed for SBOX_DEGREE<T> {}
+
+impl SBoxDegree for SBOX_DEGREE<3> {
+    const SBOX_DEGREE: usize = 3;
+
+    #[inline]
+    fn sbox_pow<F>(value: &mut F) {
+        // let mut v2 = *value;
+        // v2.square_in_place();
+        // value.mul_assign(&v2);
+        todo!()
+    }
+}
+
+impl SBoxDegree for SBOX_DEGREE<5> {
+    const SBOX_DEGREE: usize = 5;
+
+    #[inline]
+    fn sbox_pow<F>(value: &mut F) {
+        // let mut v4 = *value;
+        // v4.square_in_place();
+        // v4.square_in_place();
+        // value.mul_assign(&v4);
+        todo!()
+    }
+}
+
+impl SBoxDegree for SBOX_DEGREE<7> {
+    const SBOX_DEGREE: usize = 7;
+
+    #[inline]
+    fn sbox_pow<F>(value: &mut F) {
+        // let mut v2 = *value;
+        // v2.square_in_place();
+        // let mut v5 = *v2;
+        // v5.square_in_place();
+        // v5.mul_assign(value);
+        // v5.mul_assign(&v2);
+        todo!()
+    }
+}
+
+impl SBoxDegree for SBOX_DEGREE<11> {
+    const SBOX_DEGREE: usize = 11;
+
+    #[inline]
+    fn sbox_pow<F>(value: &mut F) {
+        todo!()
+    }
+}
+
+/// Poseidon2 Constants
+pub trait Constants {
+    /// Width of the Permutation
+    type Width: Width;
+
+    /// Degree of the S-BOX
+    type SBoxDegree: SBoxDegree;
+
+    /// Number of Full Rounds
+    const FULL_ROUNDS: usize;
+
+    /// Number of Partial Rounds
+    const PARTIAL_ROUNDS: usize;
+}
+
+/// Poseidon2 Parameter Configuration
+pub trait Config: Constants {
+    /// Field Type
+    type Field;
+}
+
+/// Poseidon2 Permutation
+pub struct Permutation<C>
+where
+    C: Config,
+{
+    /// Round Constants used for the Beginning Full Rounds
+    pub beginning_full_round_constants: Vec<C::Field>,
+
+    /// Round Constants used for the Ending Full Rounds
+    pub ending_full_round_constants: Vec<C::Field>,
+
+    /// Round Constants used for the Partial Rounds
+    pub partial_round_constants: Vec<C::Field>,
+
+    /// Internal Matrix Diagonal
+    ///
+    /// For the `WIDTH = 2` case we use the `[[2, 1], [1, 3]]` matrix and for the `WIDTH = 3` case
+    /// we use the `[[2, 1, 1], [1, 2, 1], [1, 1, 3]]` matrix. Any other values will fail
+    /// initialization with `Self::new`.
+    pub internal_matrix_diagonal: Vec<C::Field>,
+}
+
+impl<C> Permutation<C>
+where
+    C: Config,
+{
+    ///
+    pub const WIDTH: usize = C::Width::WIDTH;
+
+    ///
+    pub const SBOX_DEGREE: usize = C::SBoxDegree::SBOX_DEGREE;
+
+    ///
+    pub const FULL_ROUNDS: usize = C::FULL_ROUNDS;
+
+    ///
+    pub const PARTIAL_ROUNDS: usize = C::PARTIAL_ROUNDS;
+
+    ///
+    pub const HALF_FULL_ROUNDS: usize = C::FULL_ROUNDS / 2;
+
+    ///
+    pub const ROUNDS: usize = C::FULL_ROUNDS + C::PARTIAL_ROUNDS;
+
+    ///
+    #[inline]
+    pub fn new(
+        beginning_full_round_constants: Vec<C::Field>,
+        ending_full_round_constants: Vec<C::Field>,
+        partial_round_constants: Vec<C::Field>,
+        internal_matrix_diagonal: Vec<C::Field>,
+    ) -> Self {
+        assert_eq!(
+            beginning_full_round_constants.len(),
+            Self::HALF_FULL_ROUNDS * Self::WIDTH
+        );
+        assert_eq!(
+            ending_full_round_constants.len(),
+            Self::HALF_FULL_ROUNDS * Self::WIDTH
+        );
+        assert_eq!(partial_round_constants.len(), Self::PARTIAL_ROUNDS);
+        assert_eq!(internal_matrix_diagonal.len(), Self::WIDTH);
+        Self::new_unchecked(
+            beginning_full_round_constants,
+            ending_full_round_constants,
+            partial_round_constants,
+            internal_matrix_diagonal,
+        )
+    }
+
+    ///
+    #[inline]
+    pub fn new_unchecked(
+        beginning_full_round_constants: Vec<C::Field>,
+        ending_full_round_constants: Vec<C::Field>,
+        partial_round_constants: Vec<C::Field>,
+        internal_matrix_diagonal: Vec<C::Field>,
+    ) -> Self {
+        Self {
+            beginning_full_round_constants,
+            ending_full_round_constants,
+            partial_round_constants,
+            internal_matrix_diagonal,
+        }
+    }
+
+    ///
+    #[inline]
+    pub fn permute(&self, state: &mut [C::Field]) {
+        assert_eq!(state.len(), Self::WIDTH);
+        for round in 0..Self::HALF_FULL_ROUNDS {
+            self.add_beginning_full_round_constants(state, round);
+            Self::apply_full_sbox(state);
+            Self::matmul_external(state);
+        }
+        for round in 0..Self::PARTIAL_ROUNDS {
+            self.add_partial_round_constant(state, round);
+            Self::apply_partial_sbox(state);
+            self.matmul_internal(state);
+        }
+        for round in 0..Self::HALF_FULL_ROUNDS {
+            self.add_ending_full_round_constants(state, round);
+            Self::apply_full_sbox(state);
+            Self::matmul_external(state);
+        }
+    }
+
+    ///
+    #[inline]
+    fn add_beginning_full_round_constants(&self, state: &mut [C::Field], round: usize) {
+        // let range = round * Self::WIDTH..(round + 1) * Self::WIDTH;
+        // state
+        //     .iter_mut()
+        //     .zip(self.beginning_full_round_constants[range].iter())
+        //     .for_each(|(a, b)| a.add_assign(b));
+        todo!()
+    }
+
+    ///
+    #[inline]
+    fn add_partial_round_constant(&self, state: &mut [C::Field], round: usize) {
+        // state[0].add_assign(&self.partial_round_constants[round]);
+        todo!()
+    }
+
+    ///
+    #[inline]
+    fn add_ending_full_round_constants(&self, state: &mut [C::Field], round: usize) {
+        // let range = round * Self::WIDTH..(round + 1) * Self::WIDTH;
+        // state
+        //     .iter_mut()
+        //     .zip(self.ending_full_round_constants[range].iter())
+        //     .for_each(|(a, b)| a.add_assign(b));
+        todo!()
+    }
+
+    ///
+    #[inline]
+    fn apply_full_sbox(state: &mut [C::Field]) {
+        C::SBoxDegree::apply_sbox(state);
+    }
+
+    ///
+    #[inline]
+    fn apply_partial_sbox(state: &mut [C::Field]) {
+        C::SBoxDegree::sbox_pow(&mut state[0]);
+    }
+
+    ///
+    #[inline]
+    fn matmul_external(state: &mut [C::Field]) {
+        C::Width::matmul_external(state);
+    }
+
+    ///
+    #[inline]
+    fn matmul_internal(&self, state: &mut [C::Field]) {
+        // C::Width::matmul_internal(
+        //     state,
+        //     C::Width::internal_matrix_diagonal_from_slice(&self.internal_matrix_diagonal),
+        // );
+        todo!()
+    }
+}
+
+// TODO: Implement Chip
+//
+// ///
+// #[derive(Default)]
+// pub struct Chip {}
+//
+// impl<M> valida_machine::Chip<M> for Chip {
+//     fn generate_trace(&self, machine: &M) -> RowMajorMatrix<M::F> {
+//         todo!()
+//     }
+//
+//     fn local_sends(&self) -> Vec<Interaction<M::F>> {
+//         // TODO: Do we need this?
+//         vec![]
+//     }
+//
+//     fn local_receives(&self) -> Vec<Interaction<M::F>> {
+//         // TODO: Do we need this?
+//         vec![]
+//     }
+//
+//     fn global_sends(&self, machine: &M) -> Vec<Interaction<M::F>> {
+//         // TODO: Do we need this?
+//         vec![]
+//     }
+//
+//     fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
+//         // TODO: Do we need this?
+//         vec![]
+//     }
+// }

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -13,8 +13,10 @@
 
 extern crate alloc;
 
+use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+use core::ops::{AddAssign, MulAssign};
 use p3_matrix::dense::RowMajorMatrix;
 use valida_machine::Interaction;
 
@@ -27,8 +29,8 @@ mod sealed {
     pub trait Sealed {}
 }
 
-/// Poseidon2 Valid Width Sizes
-pub trait Width: sealed::Sealed {
+/// Poseidon2 Permutation Linear Layer
+pub trait PermutationLinearLayer: sealed::Sealed {
     /// Width of the Permutation
     const WIDTH: usize;
 
@@ -38,7 +40,9 @@ pub trait Width: sealed::Sealed {
     ///
     /// This function does not check that the length of the `state` slice is equal to the
     /// `WIDTH` constant. This should be checked by the caller.
-    fn matmul_external<F>(state: &mut [F]);
+    fn matmul_external<F>(state: &mut [F])
+    where
+        F: AddAssign<F> + Clone;
 
     /// Computes the internal matrix multiplication for the Poseidon2 Permutation.
     ///
@@ -46,222 +50,256 @@ pub trait Width: sealed::Sealed {
     ///
     /// This function does not check that the lengths of the `state` slice nor `diagonal` are
     /// equal to the `WIDTH` constant. This should be checked by the caller.
-    fn matmul_internal<F>(state: &mut [F], diagonal: &[F]);
+    fn matmul_internal<F>(state: &mut [F], diagonal: &[F])
+    where
+        F: AddAssign<F> + MulAssign<F> + Clone;
 }
 
-/// Poseidon2 Width Constant
+/// Poseidon2 Linear Layer
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct WIDTH<const T: u8>;
+pub struct LinearLayer<const T: u8>;
 
-impl<const T: u8> sealed::Sealed for WIDTH<T> {}
+impl<const T: u8> sealed::Sealed for LinearLayer<T> {}
 
-impl Width for WIDTH<2> {
+impl PermutationLinearLayer for LinearLayer<2> {
     const WIDTH: usize = 2;
 
     /// Computes the external matrix multiplication for the Poseidon2 Permutation using the
     /// `circ(2, 1)` matrix.
     #[inline]
-    fn matmul_external<F>(state: &mut [F]) {
-        // let mut sum = state[0];
-        // sum.add_assign(&state[1]);
-        // state[0].add_assign(&sum);
-        // state[1].add_assign(&sum);
-        todo!()
+    fn matmul_external<F>(state: &mut [F])
+    where
+        F: AddAssign<F> + Clone,
+    {
+        let mut sum = state[0].clone();
+        sum.add_assign(state[1].clone());
+        state[0].add_assign(sum.clone());
+        state[1].add_assign(sum);
     }
 
-    // TODO: Finish comment
-    //
-    // /// For the `WIDTH = 2` case we use the `[[2, 1], [1, 3]]` matrix.
+    /// Computes the internal matrix multiplication for the Poseidon2 Permutation using the
+    /// fixed `[[2, 1], [1, 3]]` matrix for `WIDTH = 2`.
     #[inline]
-    fn matmul_internal<F>(state: &mut [F], _: &[F]) {
-        // let mut sum = state[0];
-        // sum.add_assign(&state[1]);
-        // state[0].add_assign(&sum);
-        // state[1].double_in_place();
-        // state[1].add_assign(&sum);
-        todo!()
+    fn matmul_internal<F>(state: &mut [F], _: &[F])
+    where
+        F: AddAssign<F> + MulAssign<F> + Clone,
+    {
+        let mut sum = state[0].clone();
+        sum.add_assign(state[1].clone());
+        state[0].add_assign(sum.clone());
+        state[1].add_assign(state[1].clone());
+        state[1].add_assign(sum);
     }
 }
 
-impl Width for WIDTH<3> {
+impl PermutationLinearLayer for LinearLayer<3> {
     const WIDTH: usize = 3;
 
     /// Computes the external matrix multiplication for the Poseidon2 Permutation using the
     /// `circ(2, 1, 1)` matrix.
     #[inline]
-    fn matmul_external<F>(state: &mut [F]) {
-        // let mut sum = state[0];
-        // sum.add_assign(&state[1]);
-        // sum.add_assign(&state[2]);
-        // state[0].add_assign(&sum);
-        // state[1].add_assign(&sum);
-        // state[2].add_assign(&sum);
-        todo!()
+    fn matmul_external<F>(state: &mut [F])
+    where
+        F: AddAssign<F> + Clone,
+    {
+        let mut sum = state[0].clone();
+        sum.add_assign(state[1].clone());
+        sum.add_assign(state[2].clone());
+        state[0].add_assign(sum.clone());
+        state[1].add_assign(sum.clone());
+        state[2].add_assign(sum);
     }
 
-    // TODO: Finish comment
-    //
-    // /// For the `WIDTH = 2` case we use the `[[2, 1], [1, 3]]` matrix.
+    /// Computes the internal matrix multiplication for the Poseidon2 Permutation using the
+    /// fixed `[[2, 1, 1], [1, 2, 1], [1, 1, 3]]` matrix for `WIDTH = 3`.
     #[inline]
-    fn matmul_internal<F>(state: &mut [F], _: &[F]) {
-        // let mut sum = state[0];
-        // sum.add_assign(&state[1]);
-        // sum.add_assign(&state[2]);
-        // state[0].add_assign(&sum);
-        // state[1].add_assign(&sum);
-        // state[2].double_in_place();
-        // state[2].add_assign(&sum);
-        todo!()
+    fn matmul_internal<F>(state: &mut [F], _: &[F])
+    where
+        F: AddAssign<F> + MulAssign<F> + Clone,
+    {
+        let mut sum = state[0].clone();
+        sum.add_assign(state[1].clone());
+        sum.add_assign(state[2].clone());
+        state[0].add_assign(sum.clone());
+        state[1].add_assign(sum.clone());
+        state[2].add_assign(state[2].clone());
+        state[2].add_assign(sum);
     }
 }
 
-macro_rules! define_multiple_of_four_widths {
+/// Defines the [`LinearLayer`] constructions for `WIDTH % 4 == 0` up to `24`.
+macro_rules! define_multiple_of_four_width_linear_layers {
     ($($width:literal),+) => {
         $(
-            impl Width for WIDTH<$width> {
+            impl PermutationLinearLayer for LinearLayer<$width> {
                 const WIDTH: usize = $width;
 
                 ///
                 #[inline]
-                fn matmul_external<F>(state: &mut [F]) {
-                    // let t4 = $width / 4;
-                    // for i in 0..t4 {
-                    //     let start_index = i * 4;
-                    //     let mut t_0 = state[start_index];
-                    //     t_0.add_assign(&state[start_index + 1]);
-                    //     let mut t_1 = state[start_index + 2];
-                    //     t_1.add_assign(&state[start_index + 3]);
-                    //     let mut t_2 = state[start_index + 1];
-                    //     t_2.double_in_place();
-                    //     t_2.add_assign(&t_1);
-                    //     let mut t_3 = state[start_index + 3];
-                    //     t_3.double_in_place();
-                    //     t_3.add_assign(&t_0);
-                    //     let mut t_4 = t_1;
-                    //     t_4.double_in_place();
-                    //     t_4.double_in_place();
-                    //     t_4.add_assign(&t_3);
-                    //     let mut t_5 = t_0;
-                    //     t_5.double_in_place();
-                    //     t_5.double_in_place();
-                    //     t_5.add_assign(&t_2);
-                    //     let mut t_6 = t_3;
-                    //     t_6.add_assign(&t_5);
-                    //     let mut t_7 = t_2;
-                    //     t_7.add_assign(&t_4);
-                    //     state[start_index] = t_6;
-                    //     state[start_index + 1] = t_5;
-                    //     state[start_index + 2] = t_7;
-                    //     state[start_index + 3] = t_4;
-                    // }
-                    // let mut stored = [F::zero(); 4];
-                    // for l in 0..4 {
-                    //     stored[l] = state[l];
-                    //     for j in 1..t4 {
-                    //         stored[l].add_assign(&state[4 * j + l]);
-                    //     }
-                    // }
-                    // for i in 0..state.len() {
-                    //     state[i].add_assign(&stored[i % 4]);
-                    // }
-                    todo!()
+                fn matmul_external<F>(state: &mut [F])
+                where
+                    F: AddAssign<F> + Clone,
+                {
+                    let t4 = $width / 4;
+                    for i in 0..t4 {
+                        let start_index = i * 4;
+                        let mut t_0 = state[start_index].clone();
+                        t_0.add_assign(state[start_index + 1].clone());
+                        let mut t_1 = state[start_index + 2].clone();
+                        t_1.add_assign(state[start_index + 3].clone());
+                        let mut t_2 = state[start_index + 1].clone();
+                        t_2.add_assign(t_2.clone());
+                        t_2.add_assign(t_1.clone());
+                        let mut t_3 = state[start_index + 3].clone();
+                        t_3.add_assign(t_3.clone());
+                        t_3.add_assign(t_0.clone());
+                        let mut t_4 = t_1.clone();
+                        t_4.add_assign(t_4.clone());
+                        t_4.add_assign(t_4.clone());
+                        t_4.add_assign(t_3.clone());
+                        let mut t_5 = t_0.clone();
+                        t_5.add_assign(t_5.clone());
+                        t_5.add_assign(t_5.clone());
+                        t_5.add_assign(t_2.clone());
+                        let mut t_6 = t_3.clone();
+                        t_6.add_assign(t_5.clone());
+                        let mut t_7 = t_2.clone();
+                        t_7.add_assign(t_4.clone());
+                        state[start_index] = t_6.clone();
+                        state[start_index + 1] = t_5.clone();
+                        state[start_index + 2] = t_7.clone();
+                        state[start_index + 3] = t_4.clone();
+                    }
+                    let mut stored = state[0..4].to_owned();
+                    for l in 0..4 {
+                        for j in 1..t4 {
+                            stored[l].add_assign(state[4 * j + l].clone());
+                        }
+                    }
+                    for i in 0..state.len() {
+                        state[i].add_assign(stored[i % 4].clone());
+                    }
                 }
 
                 ///
                 #[inline]
-                fn matmul_internal<F>(state: &mut [F], diagonal: &[F]) {
-                    // let mut sum = state[0];
-                    // state.iter().skip(1).for_each(|s| sum.add_assign(s));
-                    // for i in 0..state.len() {
-                    //     state[i].mul_assign(&diagonal[i]);
-                    //     state[i].add_assign(&sum);
-                    // }
-                    todo!()
+                fn matmul_internal<F>(state: &mut [F], diagonal: &[F])
+                where
+                    F: AddAssign<F> + MulAssign<F> + Clone,
+                {
+                    let mut sum = state[0].clone();
+                    state.iter().skip(1).for_each(|s| sum.add_assign(s.clone()));
+                    for i in 0..state.len() {
+                        state[i].mul_assign(diagonal[i].clone());
+                        state[i].add_assign(sum.clone());
+                    }
                 }
             }
         )+
     };
 }
 
-define_multiple_of_four_widths!(4, 8, 12, 16, 20, 24);
+define_multiple_of_four_width_linear_layers!(4, 8, 12, 16, 20, 24);
 
-/// Poseidon2 Valid S-BOX Degrees
-pub trait SBoxDegree: sealed::Sealed {
+/// Poseidon2 Permutation S-BOX
+pub trait PermutationSBox: sealed::Sealed {
     /// Degree of the Permutation S-BOX
     const SBOX_DEGREE: usize;
 
-    /// Computes the power of `value` to the `SBOX_DEGREE`.
-    fn sbox_pow<F>(value: &mut F);
+    /// Computes the power of `x` to the `SBOX_DEGREE`.
+    fn sbox_pow<F>(x: &mut F)
+    where
+        F: MulAssign<F> + Clone;
 
     /// Applies the S-BOX power to each element in `state`.
     #[inline]
-    fn apply_sbox<F>(state: &mut [F]) {
+    fn apply_sbox<F>(state: &mut [F])
+    where
+        F: MulAssign<F> + Clone,
+    {
         state.iter_mut().for_each(Self::sbox_pow);
     }
 }
 
-/// Poseidon2 S-BOX Degree Constant
+/// Poseidon2 S-BOX
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct SBOX_DEGREE<const T: u8>;
+pub struct SBox<const T: u8>;
 
-impl<const T: u8> sealed::Sealed for SBOX_DEGREE<T> {}
+impl<const T: u8> sealed::Sealed for SBox<T> {}
 
-impl SBoxDegree for SBOX_DEGREE<3> {
+impl PermutationSBox for SBox<3> {
     const SBOX_DEGREE: usize = 3;
 
     #[inline]
-    fn sbox_pow<F>(value: &mut F) {
-        // let mut v2 = *value;
-        // v2.square_in_place();
-        // value.mul_assign(&v2);
-        todo!()
+    fn sbox_pow<F>(x: &mut F)
+    where
+        F: MulAssign<F> + Clone,
+    {
+        let mut x2 = x.clone();
+        x2.mul_assign(x.clone());
+        x.mul_assign(x2);
     }
 }
 
-impl SBoxDegree for SBOX_DEGREE<5> {
+impl PermutationSBox for SBox<5> {
     const SBOX_DEGREE: usize = 5;
 
     #[inline]
-    fn sbox_pow<F>(value: &mut F) {
-        // let mut v4 = *value;
-        // v4.square_in_place();
-        // v4.square_in_place();
-        // value.mul_assign(&v4);
-        todo!()
+    fn sbox_pow<F>(x: &mut F)
+    where
+        F: MulAssign<F> + Clone,
+    {
+        let mut x4 = x.clone();
+        x4.mul_assign(x4.clone());
+        x4.mul_assign(x4.clone());
+        x.mul_assign(x4);
     }
 }
 
-impl SBoxDegree for SBOX_DEGREE<7> {
+impl PermutationSBox for SBox<7> {
     const SBOX_DEGREE: usize = 7;
 
     #[inline]
-    fn sbox_pow<F>(value: &mut F) {
-        // let mut v2 = *value;
-        // v2.square_in_place();
-        // let mut v5 = *v2;
-        // v5.square_in_place();
-        // v5.mul_assign(value);
-        // v5.mul_assign(&v2);
-        todo!()
+    fn sbox_pow<F>(x: &mut F)
+    where
+        F: MulAssign<F> + Clone,
+    {
+        let mut x2 = x.clone();
+        x2.mul_assign(x.clone());
+        let mut x6 = x2.clone();
+        x6.mul_assign(x2.clone());
+        x6.mul_assign(x2.clone());
+        x.mul_assign(x6);
     }
 }
 
-impl SBoxDegree for SBOX_DEGREE<11> {
+impl PermutationSBox for SBox<11> {
     const SBOX_DEGREE: usize = 11;
 
     #[inline]
-    fn sbox_pow<F>(value: &mut F) {
-        todo!()
+    fn sbox_pow<F>(x: &mut F)
+    where
+        F: MulAssign<F> + Clone,
+    {
+        let mut x2 = x.clone();
+        x2.mul_assign(x.clone());
+        let mut x4 = x2.clone();
+        x4.mul_assign(x2.clone());
+        let mut x5 = x4.clone();
+        x5.mul_assign(x.clone());
+        let mut x10 = x5.clone();
+        x10.mul_assign(x5.clone());
+        x.mul_assign(x10);
     }
 }
 
 /// Poseidon2 Constants
 pub trait Constants {
-    /// Width of the Permutation
-    type Width: Width;
+    /// Permutation Linear Layer
+    type LinearLayer: PermutationLinearLayer;
 
-    /// Degree of the S-BOX
-    type SBoxDegree: SBoxDegree;
+    /// Permutation S-BOX
+    type SBox: PermutationSBox;
 
     /// Number of Full Rounds
     const FULL_ROUNDS: usize;
@@ -273,7 +311,7 @@ pub trait Constants {
 /// Poseidon2 Parameter Configuration
 pub trait Config: Constants {
     /// Field Type
-    type Field;
+    type Field: AddAssign<Self::Field> + MulAssign<Self::Field> + Clone;
 }
 
 /// Poseidon2 Permutation
@@ -303,10 +341,10 @@ where
     C: Config,
 {
     /// Permutation Width
-    pub const WIDTH: usize = C::Width::WIDTH;
+    pub const WIDTH: usize = C::LinearLayer::WIDTH;
 
     /// S-BOX Degree
-    pub const SBOX_DEGREE: usize = C::SBoxDegree::SBOX_DEGREE;
+    pub const SBOX_DEGREE: usize = C::SBox::SBOX_DEGREE;
 
     /// Number of Full Rounds
     pub const FULL_ROUNDS: usize = C::FULL_ROUNDS;
@@ -374,20 +412,21 @@ where
     #[inline]
     pub fn permute(&self, state: &mut [C::Field]) {
         assert_eq!(state.len(), Self::WIDTH);
+        C::LinearLayer::matmul_external(state);
         for round in 0..Self::HALF_FULL_ROUNDS {
             Self::add_full_round_constants(state, round, &self.beginning_full_round_constants);
-            C::SBoxDegree::apply_sbox(state);
-            C::Width::matmul_external(state);
+            C::SBox::apply_sbox(state);
+            C::LinearLayer::matmul_external(state);
         }
         for round in 0..Self::PARTIAL_ROUNDS {
             self.add_partial_round_constant(state, round);
-            C::SBoxDegree::sbox_pow(&mut state[0]);
-            C::Width::matmul_internal(state, &self.internal_matrix_diagonal);
+            C::SBox::sbox_pow(&mut state[0]);
+            C::LinearLayer::matmul_internal(state, &self.internal_matrix_diagonal);
         }
         for round in 0..Self::HALF_FULL_ROUNDS {
             Self::add_full_round_constants(state, round, &self.ending_full_round_constants);
-            C::SBoxDegree::apply_sbox(state);
-            C::Width::matmul_external(state);
+            C::SBox::apply_sbox(state);
+            C::LinearLayer::matmul_external(state);
         }
     }
 
@@ -400,16 +439,14 @@ where
     ) {
         let range = round * Self::WIDTH..(round + 1) * Self::WIDTH;
         for (a, b) in state.iter_mut().zip(round_constants[range].iter()) {
-            // TODO: a.add_assign(b);
-            todo!()
+            a.add_assign(b.clone());
         }
     }
 
     /// Adds the round constant at index `round` to the `state` for partial rounds.
     #[inline]
     fn add_partial_round_constant(&self, state: &mut [C::Field], round: usize) {
-        // TODO: state[0].add_assign(&self.partial_round_constants[round]);
-        todo!()
+        state[0].add_assign(self.partial_round_constants[round].clone());
     }
 }
 

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -6,8 +6,10 @@
 
 #![no_std]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
-#![forbid(rustdoc::broken_intra_doc_links)]
 #![forbid(missing_docs)]
+#![forbid(rustdoc::broken_intra_doc_links)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 
 extern crate alloc;
 
@@ -15,6 +17,9 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 use p3_matrix::dense::RowMajorMatrix;
 use valida_machine::Interaction;
+
+pub mod columns;
+pub mod stark;
 
 /// Sealed Trait Module
 mod sealed {

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -134,7 +134,7 @@ macro_rules! define_multiple_of_four_width_linear_layers {
             impl PermutationLinearLayer for LinearLayer<$width> {
                 const WIDTH: usize = $width;
 
-                ///
+                // TODO: Add documentation.
                 #[inline]
                 fn matmul_external<F>(state: &mut [F])
                 where
@@ -181,7 +181,7 @@ macro_rules! define_multiple_of_four_width_linear_layers {
                     }
                 }
 
-                ///
+                // TODO: Add documentation.
                 #[inline]
                 fn matmul_internal<F>(state: &mut [F], diagonal: &[F])
                 where

--- a/poseidon2/src/stark.rs
+++ b/poseidon2/src/stark.rs
@@ -18,10 +18,8 @@ where
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
 
-        // TODO: Implement Poseidon2 STARK
-        //
-        // let local: &Columns<AB::Var> = main.row(0).borrow();
-        // let next: &Columns<AB::Var> = main.row(1).borrow();
+        let local: &Columns<AB::Var> = main.row(0).borrow();
+        let next: &Columns<AB::Var> = main.row(1).borrow();
 
         todo!()
     }

--- a/poseidon2/src/stark.rs
+++ b/poseidon2/src/stark.rs
@@ -1,0 +1,18 @@
+//! Poseidon2 STARK Air Encoding
+
+///
+pub struct Stark;
+
+impl<AB> Air<AB> for Stark
+where
+    AB: AirBuilder,
+    AB::F: PrimeField,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local: &Columns<AB::Var> = main.row(0).borrow();
+        let next: &Columns<AB::Var> = main.row(1).borrow();
+
+        todo!()
+    }
+}

--- a/poseidon2/src/stark.rs
+++ b/poseidon2/src/stark.rs
@@ -18,8 +18,8 @@ where
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
 
-        let local: &Columns<AB::Var> = main.row(0).borrow();
-        let next: &Columns<AB::Var> = main.row(1).borrow();
+        // TODO: let local: &Columns<AB::Var> = main.row(0).borrow();
+        // TODO: let next: &Columns<AB::Var> = main.row(1).borrow();
 
         todo!()
     }

--- a/poseidon2/src/stark.rs
+++ b/poseidon2/src/stark.rs
@@ -1,5 +1,12 @@
 //! Poseidon2 STARK Air Encoding
 
+use crate::columns::Columns;
+use core::borrow::Borrow;
+use p3_air::Air;
+use p3_air::AirBuilder;
+use p3_field::PrimeField;
+use p3_matrix::Matrix;
+
 ///
 pub struct Stark;
 
@@ -10,8 +17,11 @@ where
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local: &Columns<AB::Var> = main.row(0).borrow();
-        let next: &Columns<AB::Var> = main.row(1).borrow();
+
+        // TODO: Implement Poseidon2 STARK
+        //
+        // let local: &Columns<AB::Var> = main.row(0).borrow();
+        // let next: &Columns<AB::Var> = main.row(1).borrow();
 
         todo!()
     }


### PR DESCRIPTION
To support recursion, we construct a hash function chip for use in the primary VM. For this hash function, we implement Poseidon2 over an arbitrary field.

For the current model of the chip, we assume that the STARKs have degree-`3` constraints, but it can be modified easily to support degree-`k` constraints.

**NB**: This branch may rely on changes in Plonky3 at this branch: [bhgomes/poseidon2-chip](https://github.com/bhgomes/Plonky3/tree/bhgomes/poseidon2-chip).

## TODO

- [ ] Hook the STARK impl from the `columns.rs` file to the `stark.rs` file (do we really need both?)
- [ ] Get constants for `mersenne-31`
- [ ] Write Instance Test
