### PR TITLE
Minor refactor

### DIFF
--- a/alu_u32/src/add/stark.rs
+++ b/alu_u32/src/add/stark.rs
@@ -3,7 +3,7 @@ use super::{Add32Chip, ADD32_OPCODE};
 use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder};
-use p3_field::PrimeField;
+use p3_field::{AbstractField, PrimeField};
 use p3_matrix::MatrixRows;
 
 impl<F, AB> Air<AB> for Add32Chip
@@ -16,7 +16,7 @@ where
         let local: &Add32Cols<AB::Var> = main.row(0).borrow();
 
         let one = AB::F::ONE;
-        let base = AB::Expr::from(AB::F::from_canonical_u32(1 << 8));
+        let base = AB::F::from_canonical_u32(1 << 8);
 
         let carry_1 = local.carry[0];
         let carry_2 = local.carry[1];
@@ -43,9 +43,6 @@ where
         builder.assert_zero(overflow_2.clone() * (carry_3 - one) + (overflow_2 - base) * carry_3);
 
         // Bus opcode constraint
-        builder.assert_eq(
-            local.opcode,
-            AB::Expr::from(AB::F::from_canonical_u32(ADD32_OPCODE)),
-        );
+        builder.assert_eq(local.opcode, AB::Expr::from_canonical_u32(ADD32_OPCODE));
     }
 }

--- a/alu_u32/src/sub/stark.rs
+++ b/alu_u32/src/sub/stark.rs
@@ -3,7 +3,7 @@ use super::{Sub32Chip, SUB32_OPCODE};
 use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder};
-use p3_field::PrimeField;
+use p3_field::{AbstractField, PrimeField};
 use p3_matrix::MatrixRows;
 
 impl<F, AB> Air<AB> for Sub32Chip
@@ -15,7 +15,7 @@ where
         let main = builder.main();
         let local: &Sub32Cols<AB::Var> = main.row(0).borrow();
 
-        let base = AB::Expr::from(AB::F::from_canonical_u32(1 << 8));
+        let base = AB::Expr::from_canonical_u32(1 << 8);
 
         let sub_0 = local.input_1[3] - local.input_2[3];
         let sub_1 = local.input_1[2] - local.input_2[2];
@@ -29,23 +29,18 @@ where
 
         // First byte
         builder.assert_zero(borrow_0.clone() * (base.clone() - sub_0 - local.output[3]));
-        builder
-            .assert_zero(borrow_0 * (sub_1.clone() - local.output[2] - AB::Expr::from(AB::F::ONE)));
+        builder.assert_zero(borrow_0 * (sub_1.clone() - local.output[2] - AB::Expr::ONE));
 
         // Second byte
         builder.assert_zero(borrow_1.clone() * (base.clone() - sub_1 - local.output[2]));
-        builder
-            .assert_zero(borrow_1 * (sub_2.clone() - local.output[1] - AB::Expr::from(AB::F::ONE)));
+        builder.assert_zero(borrow_1 * (sub_2.clone() - local.output[1] - AB::Expr::ONE));
 
         // Third byte
         builder.assert_zero(borrow_2.clone() * (base.clone() - sub_2 - local.output[1]));
-        builder.assert_zero(borrow_2 * (sub_3 - local.output[0] - AB::Expr::from(AB::F::ONE)));
+        builder.assert_zero(borrow_2 * (sub_3 - local.output[0] - AB::Expr::ONE));
 
         // Bus opcode constraint
-        builder.assert_eq(
-            local.opcode,
-            AB::Expr::from(AB::F::from_canonical_u32(SUB32_OPCODE)),
-        );
+        builder.assert_eq(local.opcode, AB::Expr::from_canonical_u32(SUB32_OPCODE));
 
         todo!()
     }

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -1,14 +1,12 @@
 use crate::columns::CpuCols;
 use crate::CpuChip;
 use core::borrow::Borrow;
-use core::mem::MaybeUninit;
 use valida_machine::Word;
 
 use p3_air::{Air, AirBuilder};
 use p3_field::{AbstractField, PrimeField};
 use p3_matrix::MatrixRows;
 
-#[allow(clippy::uninit_assumed_init)]
 impl<F, AB> Air<AB> for CpuChip
 where
     F: PrimeField,
@@ -19,10 +17,7 @@ where
         let local: &CpuCols<AB::Var> = main.row(0).borrow();
         let next: &CpuCols<AB::Var> = main.row(1).borrow();
 
-        let mut base: [AB::Expr; 4] = unsafe { MaybeUninit::uninit().assume_init() };
-        for (i, b) in [1 << 24, 1 << 16, 1 << 8, 1].into_iter().enumerate() {
-            base[i] = AB::Expr::from(AB::F::from_canonical_u32(b));
-        }
+        let base = [1 << 24, 1 << 16, 1 << 8, 1].map(AB::Expr::from_canonical_u32);
 
         self.eval_pc(builder, local, next, &base);
         self.eval_fp(builder, local, next, &base);
@@ -33,12 +28,12 @@ where
         builder.when_first_row().assert_zero(local.clk);
         builder
             .when_transition()
-            .assert_eq(local.clk + AB::Expr::from(AB::F::ONE), next.clk);
+            .assert_eq(local.clk + AB::Expr::ONE, next.clk);
         builder
             .when(local.opcode_flags.is_bus_op_with_mem)
             .assert_eq(local.clk, local.chip_channel.clk_or_zero);
         builder
-            .when(AB::Expr::from(AB::F::ONE) - local.opcode_flags.is_bus_op_with_mem)
+            .when(AB::Expr::ONE - local.opcode_flags.is_bus_op_with_mem)
             .assert_zero(local.chip_channel.clk_or_zero);
 
         // Immediate value constraints (TODO: we'd need to range check read_value_2 in
@@ -97,16 +92,10 @@ impl CpuChip {
             reduce::<AB>(base, local.read_value_1()),
         );
         builder
-            .when(
-                is_jalv + (AB::Expr::from(AB::F::ONE) - is_imm_op) * (is_beq + is_bne + is_bus_op),
-            )
+            .when(is_jalv + (AB::Expr::ONE - is_imm_op) * (is_beq + is_bne + is_bus_op))
             .assert_eq(local.read_addr_2(), addr_c);
         builder
-            .when(
-                is_load
-                    + is_jalv
-                    + (AB::Expr::from(AB::F::ONE) - is_imm_op) * (is_beq + is_bne + is_bus_op),
-            )
+            .when(is_load + is_jalv + (AB::Expr::ONE - is_imm_op) * (is_beq + is_bne + is_bus_op))
             .assert_one(local.read_2_used());
         builder
             .when(is_store + is_jal + is_imm_op * (is_beq + is_bne + is_bus_op))
@@ -167,7 +156,7 @@ impl CpuChip {
             .assert_eq(next.pc, incremented_pc.clone());
 
         // Branch manipulation
-        let equal = AB::Expr::from(AB::F::ONE) - local.not_equal;
+        let equal = AB::Expr::ONE - local.not_equal;
         let next_pc_if_branching = local.instruction.operands.a();
         let beq_next_pc =
             equal.clone() * next_pc_if_branching.clone() + local.not_equal * incremented_pc.clone();


### PR DESCRIPTION
- Prefer constructors on `AB::Expr` directly
- Replace a few uses of `MaybeUninit` (we can use array maps or `core::array::from_fn` for this sort of thing)