### PR TITLE
Alu32- Div Chip

### DIFF
--- a/alu_u32/src/div/columns.rs
+++ b/alu_u32/src/div/columns.rs
@@ -11,6 +11,14 @@ pub struct Div32Cols<T> {
 
     /// Witnessed output
     pub output: Word<T>,
+
+    /// Witnessed quotients in the congruence relation
+    pub r: T,
+    pub s: T,
+
+    pub is_real: T,
+
+    pub counter: T,
 }
 
 pub const NUM_DIV_COLS: usize = size_of::<Div32Cols<u8>>();

--- a/alu_u32/src/div/stark.rs
+++ b/alu_u32/src/div/stark.rs
@@ -1,6 +1,8 @@
 use super::columns::Div32Cols;
 use super::Div32Chip;
 use core::borrow::Borrow;
+use itertools::iproduct;
+use valida_machine::Word;
 
 use p3_air::{Air, AirBuilder};
 use p3_field::{AbstractField, PrimeField};
@@ -12,6 +14,64 @@ where
     AB: AirBuilder<F = F>,
 {
     fn eval(&self, builder: &mut AB) {
-        // TODO
+        let main = builder.main();
+        let local: &Div32Cols<AB::Var> = main.row(0).borrow();
+        let next: &Div32Cols<AB::Var> = main.row(1).borrow();
+
+        // output = input_1 / input_2
+        // therefore, by rearranging, input_1 = output * input_2 and we can apply the
+        // same congruence checks as in the multiplication case.
+
+        // Limb weights modulo 2^32
+        let base_m = [1 << 24, 1 << 16, 1 << 8, 1].map(AB::Expr::from_canonical_u32);
+
+        // Partially reduced summation of input product limbs (mod 2^32)
+        let pi = pi_m::<4, AB>(&base_m, local.output, local.input_2);
+
+        // Partially reduced summation of output limbs (mod 2^32)
+        let sigma = sigma_m::<4, AB>(&base_m, local.input_1);
+
+        // Partially reduced summation of input product limbs (mod 2^16)
+        let pi_prime = pi_m::<2, AB>(&base_m[..2], local.output, local.input_2);
+
+        // Partially reduced summation of output limbs (mod 2^16)
+        let sigma_prime = sigma_m::<2, AB>(&base_m[..2], local.input_1);
+
+        // Congruence checks
+        builder.assert_eq(pi - sigma, local.r * AB::Expr::TWO);
+        builder.assert_eq(pi_prime - sigma_prime, local.s * base_m[1].clone());
+
+        // Range check counter
+        builder
+            .when_first_row()
+            .assert_eq(local.counter, AB::Expr::ONE);
+        builder.when_transition().assert_zero(
+            (local.counter - next.counter) * (local.counter + AB::Expr::ONE - next.counter),
+        );
+        builder
+            .when_last_row()
+            .assert_eq(local.counter, AB::Expr::from_canonical_u32(1 << 10));
     }
+}
+
+// HELPER FUNCTIONS
+// -------------------------------------------------------------------------------------------------
+
+fn pi_m<const N: usize, AB: AirBuilder>(
+    base: &[AB::Expr],
+    input_1: Word<AB::Var>,
+    input_2: Word<AB::Var>,
+) -> AB::Expr {
+    iproduct!(0..N, 0..N)
+        .filter(|(i, j)| i + j < N)
+        .map(|(i, j)| base[i + j].clone() * input_1[i] * input_2[j])
+        .sum()
+}
+
+fn sigma_m<const N: usize, AB: AirBuilder>(base: &[AB::Expr], input: Word<AB::Var>) -> AB::Expr {
+    input
+        .into_iter()
+        .enumerate()
+        .map(|(i, x)| base[i].clone() * x)
+        .sum()
 }

--- a/machine/src/core.rs
+++ b/machine/src/core.rs
@@ -80,6 +80,7 @@ impl Mul for Word<u8> {
 
 impl Div for Word<u8> {
     type Output = Self;
+
     fn div(self, other: Self) -> Self {
         let b: u32 = self.into();
         let c: u32 = other.into();


### PR DESCRIPTION
This PR introduces a `DIV` chip to the VM. The chip only supports floor division as the general bus can only send three values at a time. The AIR constraints would be quite similar to `MUL` operation after some rearranging. 

 $a = b / c$ can be rearranged to $a * c = b$ and then we can apply the `MUL` AIR constraints.