### PR TITLE
README: Replace "echo" with "printf"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Our roadmap also includes implementing fast recursion and continuations to enabl
 ## Interpreter
 A standalone binary interpreter is available to execute Valida programs (skipping proof generation), and can be built by running `cargo build --release`.
 
-For example, the 25th Fibonacci number can be returned by executing the command `echo -n '\x19' | ./target/release/valida basic/tests/data/fibonacci.bin | hexdump`.
+For example, the 25th Fibonacci number can be returned by executing the command `printf "\x19" | ./target/release/valida basic/tests/data/fibonacci.bin | hexdump`.
 
 ## Tests
 A proof of a Fibonacci program execution can be generated and tested for soundness by running `cargo test prove_fibonacci`.


### PR DESCRIPTION
Resolves https://github.com/valida-xyz/valida/issues/33

The `echo` command given in the README does not produce the expected results on all systems. On my machine (x86, PopOS, bash shell) the example `echo` inputs 4 bytes to the interpreter. I confirmed this by editing the `valida` interpreter to show the input bytes:

```console
$ echo -n "\x19" | time ./target/release/valida basic/tests/data/fibonacci.bin
Input bytes: 4
92
120
49
57
```

Using an [ASCII table](https://www.asciitable.com/), it is apparent that 92 is '\\', 120 is 'x', etc. In other words, `echo` is not parsing the string as expected.

Changing to `printf` fixes this. See [this post](https://unix.stackexchange.com/a/65819) for a discussion about the differences between `echo` and `printf` re: cross-platform portability.

NOTE: I don't have a Mac to test this on.