### PR TITLE
Fix bus constraints

### DIFF
--- a/alu_u32/src/add/mod.rs
+++ b/alu_u32/src/add/mod.rs
@@ -50,19 +50,20 @@ where
     }
 
     fn global_sends(&self, machine: &M) -> Vec<Interaction<M::F>> {
-        let output = ADD_COL_MAP
+        let sends = ADD_COL_MAP
             .output
             .0
-            .map(VirtualPairCol::single_main)
+            .map(|field| {
+                let output = VirtualPairCol::single_main(field);
+                Interaction {
+                    fields: vec![output],
+                    count: VirtualPairCol::single_main(ADD_COL_MAP.is_real),
+                    argument_index: machine.range_bus(),
+                }
+            })
             .into_iter()
             .collect::<Vec<_>>();
-
-        let send = Interaction {
-            fields: output,
-            count: VirtualPairCol::one(),
-            argument_index: machine.range_bus(),
-        };
-        vec![send]
+        sends
     }
 
     fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
@@ -112,6 +113,7 @@ impl Add32Chip {
                 if b[1] as u32 + c[1] as u32 + carry_2 > 255 {
                     cols.carry[2] = F::ONE;
                 }
+                cols.is_real = F::ONE;
             }
         }
         row

--- a/alu_u32/src/lt/stark.rs
+++ b/alu_u32/src/lt/stark.rs
@@ -42,14 +42,18 @@ where
         // Check final byte (if no other byte flags were set)
         let flag_sum = local.byte_flag[0] + local.byte_flag[1] + local.byte_flag[2];
         builder.assert_bool(flag_sum.clone());
-        builder.when_ne(flag_sum, AB::Expr::ONE).assert_eq(
-            AB::Expr::from_canonical_u32(256) + local.input_1[3] - local.input_2[3],
-            bit_comp.clone(),
-        );
+        builder
+            .when_ne(local.multiplicity, AB::Expr::ZERO)
+            .when_ne(flag_sum, AB::Expr::ONE)
+            .assert_eq(
+                AB::Expr::from_canonical_u32(256) + local.input_1[3] - local.input_2[3],
+                bit_comp.clone(),
+            );
 
         // Output constraints
         builder.when(local.bits[8]).assert_zero(local.output);
         builder
+            .when_ne(local.multiplicity, AB::Expr::ZERO)
             .when_ne(local.bits[8], AB::Expr::ONE)
             .assert_one(local.output);
 

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -21,7 +21,6 @@ use p3_symmetric::sponge::PaddingFreeSponge;
 use rand::thread_rng;
 
 #[test]
-#[ignore]
 fn prove_fibonacci() {
     let mut program = vec![];
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -216,6 +216,10 @@ fn prove_method(chips: &[&Field]) -> TokenStream2 {
 
             let mut chip_proofs = vec![];
             #prove_starks
+
+            #[cfg(debug_assertions)]
+            check_cumulative_sums::<Self>(&perm_traces[..]);
+
             MachineProof {
                 // opening_proof,
                 chip_proofs,

--- a/machine/src/__internal/check_constraints.rs
+++ b/machine/src/__internal/check_constraints.rs
@@ -63,3 +63,21 @@ pub fn check_constraints<M, A>(
         eval_permutation_constraints(air, &mut builder, cumulative_sum);
     });
 }
+
+pub fn check_cumulative_sums<M>(perms: &[RowMajorMatrix<M::EF>])
+where
+    M: Machine + Sync,
+{
+    let sum: M::EF = perms
+        .iter()
+        .map(|perm| {
+            let sum = if perm.height() > 0 {
+                *perm.row_slice(perm.height() - 1).last().unwrap()
+            } else {
+                M::EF::ZERO
+            };
+            sum
+        })
+        .sum();
+    assert_eq!(sum, M::EF::ZERO);
+}

--- a/machine/src/__internal/check_constraints.rs
+++ b/machine/src/__internal/check_constraints.rs
@@ -64,20 +64,14 @@ pub fn check_constraints<M, A>(
     });
 }
 
+/// Check that the combined cumulative sum across all lookup tables is zero.
 pub fn check_cumulative_sums<M>(perms: &[RowMajorMatrix<M::EF>])
 where
     M: Machine + Sync,
 {
     let sum: M::EF = perms
         .iter()
-        .map(|perm| {
-            let sum = if perm.height() > 0 {
-                *perm.row_slice(perm.height() - 1).last().unwrap()
-            } else {
-                M::EF::ZERO
-            };
-            sum
-        })
+        .map(|perm| *perm.row_slice(perm.height() - 1).last().unwrap())
         .sum();
     assert_eq!(sum, M::EF::ZERO);
 }

--- a/machine/src/chip.rs
+++ b/machine/src/chip.rs
@@ -146,17 +146,19 @@ where
     let mut perm = RowMajorMatrix::new(perm_values, perm_width);
 
     // Compute the running sum column
-    let mut phi = vec![M::EF::ZERO; perm.height() + 1];
+    let mut phi = vec![M::EF::ZERO; perm.height()];
     for (n, (main_row, perm_row)) in main.rows().zip(perm.rows()).enumerate() {
-        phi[n + 1] = phi[n];
+        if n > 0 {
+            phi[n] = phi[n - 1];
+        }
         for (m, (interaction, interaction_type)) in all_interactions.iter().enumerate() {
             let mult = interaction.count.apply::<M::F, M::F>(&[], main_row);
             match interaction_type {
                 InteractionType::LocalSend | InteractionType::GlobalSend => {
-                    phi[n + 1] += M::EF::from_base(mult) * perm_row[m];
+                    phi[n] += M::EF::from_base(mult) * perm_row[m];
                 }
                 InteractionType::LocalReceive | InteractionType::GlobalReceive => {
-                    phi[n + 1] -= M::EF::from_base(mult) * perm_row[m];
+                    phi[n] -= M::EF::from_base(mult) * perm_row[m];
                 }
             }
         }
@@ -180,6 +182,7 @@ where
 
     let main = builder.main();
     let main_local: &[AB::Var] = main.row_slice(0);
+    let main_next: &[AB::Var] = main.row_slice(1);
 
     let perm = builder.permutation();
     let perm_width = perm.width();
@@ -196,6 +199,7 @@ where
 
     let lhs = phi_next - phi_local.clone();
     let mut rhs = AB::ExprEF::from_base(AB::Expr::ZERO);
+    let mut phi_0 = AB::ExprEF::from_base(AB::Expr::ZERO);
     for (m, (interaction, interaction_type)) in all_interactions.iter().enumerate() {
         // Reciprocal constraints
         let mut rlc = AB::ExprEF::from_base(AB::Expr::ZERO);
@@ -210,16 +214,20 @@ where
         }
         builder.assert_one_ext::<AB::ExprEF, AB::ExprEF>(rlc * perm_local[m]);
 
-        // Build the RHS of the permutation constraint
-        let mult = interaction
+        let mult_local = interaction
             .count
             .apply::<AB::Expr, AB::Var>(&[], main_local);
+        let mult_next = interaction.count.apply::<AB::Expr, AB::Var>(&[], main_next);
+
+        // Build the RHS of the permutation constraint
         match interaction_type {
             InteractionType::LocalSend | InteractionType::GlobalSend => {
-                rhs += AB::ExprEF::from_base(mult) * perm_local[m];
+                phi_0 += AB::ExprEF::from_base(mult_local) * perm_local[m];
+                rhs += AB::ExprEF::from_base(mult_next) * perm_next[m];
             }
             InteractionType::LocalReceive | InteractionType::GlobalReceive => {
-                rhs -= AB::ExprEF::from_base(mult) * perm_local[m];
+                phi_0 -= AB::ExprEF::from_base(mult_local) * perm_local[m];
+                rhs -= AB::ExprEF::from_base(mult_next) * perm_next[m];
             }
         }
     }
@@ -228,7 +236,9 @@ where
     builder
         .when_transition()
         .assert_eq_ext::<AB::ExprEF, _, _>(lhs, rhs);
-    builder.when_first_row().assert_zero_ext(phi_local);
+    builder
+        .when_first_row()
+        .assert_eq_ext(perm_local.last().unwrap().clone(), phi_0);
     builder.when_last_row().assert_eq_ext(
         perm_local.last().unwrap().clone(),
         AB::ExprEF::from(cumulative_sum),

--- a/memory/src/stark.rs
+++ b/memory/src/stark.rs
@@ -44,6 +44,7 @@ impl MemoryChip {
             builder
                 .when_transition()
                 .when(next.is_read)
+                .when(next.is_real) // FIXME: Degree constraint 4, need to remove
                 .when_ne(local.addr_not_equal, AB::Expr::ONE)
                 .assert_eq(value_next, value);
         }

--- a/native_field/src/lib.rs
+++ b/native_field/src/lib.rs
@@ -53,22 +53,23 @@ where
     }
 
     fn global_sends(&self, machine: &M) -> Vec<Interaction<M::F>> {
-        let output = COL_MAP
+        let sends = COL_MAP
             .output
             .0
-            .map(VirtualPairCol::single_main)
+            .map(|field| {
+                let output = VirtualPairCol::single_main(field);
+                let is_real =
+                    VirtualPairCol::sum_main(vec![COL_MAP.is_add, COL_MAP.is_sub, COL_MAP.is_mul]);
+
+                Interaction {
+                    fields: vec![output],
+                    count: is_real,
+                    argument_index: machine.range_bus(),
+                }
+            })
             .into_iter()
             .collect::<Vec<_>>();
-
-        let is_real =
-            VirtualPairCol::sum_main(vec![COL_MAP.is_add, COL_MAP.is_sub, COL_MAP.is_mul]);
-
-        let send = Interaction {
-            fields: output,
-            count: is_real,
-            argument_index: machine.range_bus(),
-        };
-        vec![send]
+        sends
     }
 
     fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {

--- a/native_field/src/lib.rs
+++ b/native_field/src/lib.rs
@@ -11,6 +11,7 @@ use valida_cpu::MachineWithCpuChip;
 use valida_machine::{instructions, Chip, Instruction, Interaction, Machine, Operands, Word};
 use valida_opcodes::{ADD, MUL, SUB};
 use valida_range::MachineWithRangeChip;
+use valida_util::pad_to_power_of_two;
 
 use p3_air::VirtualPairCol;
 use p3_field::{Field, PrimeField32};
@@ -46,7 +47,7 @@ where
         let mut trace =
             RowMajorMatrix::new(rows.into_iter().flatten().collect::<Vec<_>>(), NUM_COLS);
 
-        Self::pad_to_power_of_two::<NUM_COLS, M::F>(&mut trace.values);
+        pad_to_power_of_two::<NUM_COLS, M::F>(&mut trace.values);
 
         trace
     }
@@ -142,7 +143,7 @@ instructions!(AddInstruction, SubInstruction, MulInstruction);
 
 impl<F, M> Instruction<M> for AddInstruction
 where
-    M: MachineWithNativeFieldChip + MachineWithRangeChip + Machine<F = F>,
+    M: MachineWithNativeFieldChip + MachineWithRangeChip<256> + Machine<F = F>,
     F: PrimeField32,
 {
     const OPCODE: u32 = ADD;
@@ -180,7 +181,7 @@ where
 
 impl<F, M> Instruction<M> for SubInstruction
 where
-    M: MachineWithNativeFieldChip + MachineWithRangeChip + Machine<F = F>,
+    M: MachineWithNativeFieldChip + MachineWithRangeChip<256> + Machine<F = F>,
     F: PrimeField32,
 {
     const OPCODE: u32 = SUB;
@@ -218,7 +219,7 @@ where
 
 impl<F, M> Instruction<M> for MulInstruction
 where
-    M: MachineWithNativeFieldChip + MachineWithRangeChip + Machine<F = F>,
+    M: MachineWithNativeFieldChip + MachineWithRangeChip<256> + Machine<F = F>,
     F: PrimeField32,
 {
     const OPCODE: u32 = MUL;

--- a/output/src/lib.rs
+++ b/output/src/lib.rs
@@ -82,28 +82,31 @@ where
             rows.push(row);
         }
 
+        // TODO: Implement witness data for counter and counter_mult, and then
+        // re-enable local_sends and local_receives
+
         let mut values = rows.concat();
         pad_to_power_of_two::<NUM_OUTPUT_COLS, F>(&mut values);
         RowMajorMatrix::new(values, NUM_OUTPUT_COLS)
     }
 
-    fn local_sends(&self) -> Vec<Interaction<M::F>> {
-        let sends = Interaction {
-            fields: vec![VirtualPairCol::single_main(OUTPUT_COL_MAP.diff)],
-            count: VirtualPairCol::one(),
-            argument_index: BusArgument::Local(0),
-        };
-        vec![sends]
-    }
+    //fn local_sends(&self) -> Vec<Interaction<M::F>> {
+    //    let sends = Interaction {
+    //        fields: vec![VirtualPairCol::single_main(OUTPUT_COL_MAP.diff)],
+    //        count: VirtualPairCol::one(),
+    //        argument_index: BusArgument::Local(0),
+    //    };
+    //    vec![sends]
+    //}
 
-    fn local_receives(&self) -> Vec<Interaction<M::F>> {
-        let receives = Interaction {
-            fields: vec![VirtualPairCol::single_main(OUTPUT_COL_MAP.counter)],
-            count: VirtualPairCol::single_main(OUTPUT_COL_MAP.counter_mult),
-            argument_index: BusArgument::Local(0),
-        };
-        vec![receives]
-    }
+    //fn local_receives(&self) -> Vec<Interaction<M::F>> {
+    //    let receives = Interaction {
+    //        fields: vec![VirtualPairCol::single_main(OUTPUT_COL_MAP.counter)],
+    //        count: VirtualPairCol::single_main(OUTPUT_COL_MAP.counter_mult),
+    //        argument_index: BusArgument::Local(0),
+    //    };
+    //    vec![receives]
+    //}
 
     fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
         let opcode = VirtualPairCol::single_main(OUTPUT_COL_MAP.opcode);

--- a/output/src/stark.rs
+++ b/output/src/stark.rs
@@ -26,7 +26,7 @@ where
             .assert_eq(next.counter, local.counter + AB::Expr::from(AB::F::ONE));
 
         // Bus opcode constraint
-        builder.assert_eq(
+        builder.when(local.is_real).assert_eq(
             local.opcode,
             AB::Expr::from(AB::F::from_canonical_u32(WRITE)),
         );

--- a/range/Cargo.toml
+++ b/range/Cargo.toml
@@ -11,4 +11,6 @@ p3-field = { path = "../../Plonky3/field" }
 p3-matrix = { path = "../../Plonky3/matrix" }
 p3-maybe-rayon = { path = "../../Plonky3/maybe-rayon" }
 
+valida-bus = { path = "../bus" }
 valida-machine = { path = "../machine" }
+valida-util = { path = "../util" }

--- a/range/src/columns.rs
+++ b/range/src/columns.rs
@@ -1,8 +1,20 @@
+use core::mem::{size_of, transmute};
+use valida_util::indices_arr;
+
 #[derive(Default)]
 pub struct RangeCols<T> {
     pub mult: T, // Multiplicity
+    pub counter: T,
 }
 
-pub struct RangePreprocessedCols<T> {
-    pub counter: T,
+pub struct RangePreprocessedCols {
+    // TODO
+}
+
+pub const NUM_RANGE_COLS: usize = size_of::<RangeCols<u8>>();
+pub const RANGE_COL_MAP: RangeCols<usize> = make_col_map();
+
+const fn make_col_map() -> RangeCols<usize> {
+    let indices_arr = indices_arr::<NUM_RANGE_COLS>();
+    unsafe { transmute::<[usize; NUM_RANGE_COLS], RangeCols<usize>>(indices_arr) }
 }

--- a/range/src/lib.rs
+++ b/range/src/lib.rs
@@ -4,8 +4,14 @@ extern crate alloc;
 
 use alloc::collections::BTreeMap;
 use alloc::vec;
+use alloc::vec::Vec;
+use columns::{RangeCols, NUM_RANGE_COLS, RANGE_COL_MAP};
+use core::mem::transmute;
+use valida_bus::MachineWithRangeBus8;
+use valida_machine::Interaction;
 use valida_machine::{Chip, Machine, PrimeField, Word};
 
+use p3_air::VirtualPairCol;
 use p3_matrix::dense::RowMajorMatrix;
 
 pub mod columns;
@@ -19,16 +25,31 @@ pub struct RangeCheckerChip<const MAX: u32> {
 impl<F, M, const MAX: u32> Chip<M> for RangeCheckerChip<MAX>
 where
     F: PrimeField,
-    M: Machine<F = F>,
+    M: MachineWithRangeBus8<F = F>,
 {
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<M::F> {
-        let mut col = vec![M::F::ZERO; MAX as usize];
-        for n in 0..MAX {
-            if let Some(c) = self.count.get(&n) {
-                col[n as usize] = M::F::from_canonical_u32(*c);
+        let mut rows = vec![[F::ZERO; NUM_RANGE_COLS]; MAX as usize];
+        for (n, row) in rows.iter_mut().enumerate() {
+            let cols: &mut RangeCols<F> = unsafe { transmute(row) };
+            // FIXME: This is very inefficient when the range is large.
+            // Iterate over key/val pairs instead in a separate loop.
+            if let Some(c) = self.count.get(&(n as u32)) {
+                cols.mult = M::F::from_canonical_u32(*c);
             }
+            cols.counter = M::F::from_canonical_u32(n as u32);
         }
-        RowMajorMatrix::new(col, 1)
+        RowMajorMatrix::new(rows.concat(), NUM_RANGE_COLS)
+    }
+
+    fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
+        let input = VirtualPairCol::single_main(RANGE_COL_MAP.counter);
+
+        let receive = Interaction {
+            fields: vec![input],
+            count: VirtualPairCol::single_main(RANGE_COL_MAP.mult),
+            argument_index: machine.range_bus(),
+        };
+        vec![receive]
     }
 }
 


### PR DESCRIPTION
Added a `check_cumulative_sums` function that confirms that the combined cumulative sum in all bus interactions balances out to zero. This function is run as a debug assertion, and is now passing for the Fibonacci prover test.