### PR TITLE
Update `prove_fibonacci` to use Keccak

### DIFF
--- a/basic/Cargo.toml
+++ b/basic/Cargo.toml
@@ -27,6 +27,7 @@ p3-challenger = { path = "../../Plonky3/challenger" }
 p3-dft = { path = "../../Plonky3/dft" }
 p3-field = { path = "../../Plonky3/field" }
 p3-fri = { path = "../../Plonky3/fri" }
+p3-keccak = { path = "../../Plonky3/keccak" }
 p3-ldt = { path = "../../Plonky3/ldt" }
 p3-mds = { path = "../../Plonky3/mds" }
 p3-merkle-tree = { path = "../../Plonky3/merkle-tree" }


### PR DESCRIPTION
This brings the speed up to ~50 KHz on my M1. Keccak is far from the fastest hash (e.g. KangarooTwelve halves its rounds), so this isn't the best long-term solution, but more of a stopgap until we have something better.