### PR TITLE
let memory never written to be zero

### DIFF
--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -63,7 +63,8 @@ impl MemoryChip {
     }
 
     pub fn read(&mut self, clk: u32, address: u32, log: bool) -> Word<u8> {
-        let value = self.cells.get(&address.into()).copied().unwrap();
+        let value = self.cells.get(&address.into()).copied()
+                      .unwrap_or(<Word<u8> as From<u32>>::from(0));
         if log {
             self.operations
                 .entry(clk)


### PR DESCRIPTION
This PR allows programs running in the emulator to reference memory before they write it, with the result being zero. I'm not sure how necessary this is; it's come up, but only in buggy code. I don't think programs can normally rely on memory being set to a value before it's written.