### PR TITLE
Make `run_fibonacci()` an in-process test

### DIFF
--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::io::{Read, Write};
+use std::io::{stdin, stdout, Read, Write};
 
 use valida_basic::BasicMachine;
 use valida_cpu::MachineWithCpuChip;
@@ -31,7 +31,7 @@ fn main() {
 
     // Read standard input into the advice tape
     let mut input_bytes = Vec::new();
-    std::io::stdin().read_to_end(&mut input_bytes).unwrap();
+    stdin().read_to_end(&mut input_bytes).unwrap();
     let input_words = input_bytes
         .chunks(MEMORY_CELL_BYTES)
         .map(|chunk| {
@@ -51,14 +51,5 @@ fn main() {
     machine.run(&rom);
 
     // Write output chip values to standard output
-    std::io::stdout()
-        .write_all(
-            &machine
-                .output()
-                .values
-                .iter()
-                .map(|(_, b)| *b)
-                .collect::<Vec<_>>(),
-        )
-        .unwrap();
+    stdout().write_all(&machine.output().bytes()).unwrap();
 }

--- a/basic/tests/test_interpreter.rs
+++ b/basic/tests/test_interpreter.rs
@@ -24,12 +24,7 @@ fn run_fibonacci() {
 
     // Run the program
     machine.run(&rom);
-    let output = machine
-        .output()
-        .values
-        .iter()
-        .map(|(_, b)| *b)
-        .collect::<Vec<_>>();
+    let output = machine.output().bytes();
     assert_eq!(output.len(), 4);
     let actual_result = u32::from_le_bytes(output.try_into().unwrap());
 

--- a/basic/tests/test_interpreter.rs
+++ b/basic/tests/test_interpreter.rs
@@ -1,31 +1,40 @@
-use std::io::Cursor;
-use std::io::Read;
-use std::process::{Command, Stdio};
-
-use byteorder::{LittleEndian, WriteBytesExt};
+use p3_baby_bear::BabyBear;
+use valida_basic::BasicMachine;
+use valida_cpu::MachineWithCpuChip;
+use valida_machine::{Machine, ProgramROM, Word};
+use valida_output::MachineWithOutputChip;
+use valida_program::MachineWithProgramChip;
 
 #[test]
 fn run_fibonacci() {
-    // Execute the fibonacci binary
+    let mut machine = BasicMachine::<BabyBear, BabyBear>::default();
     let filepath = "tests/programs/binary/fibonacci.bin";
-    let fib_number = 25;
-    let mut child = Command::new("cargo")
-        .args(&["run", "--bin", "valida", filepath])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("failed to execute process");
-    let stdin = child.stdin.as_mut().expect("failed to get stdin");
-    stdin.write_u32::<LittleEndian>(fib_number).unwrap();
+    let rom = ProgramROM::from_file(filepath).unwrap();
+    machine.program_mut().set_program_rom(&rom);
+    machine.cpu_mut().fp = 16777216; // default stack height
+    machine.cpu_mut().save_register_state();
 
-    // Compare stdout with the expected value in the Fibonacci sequence
-    let value = fibonacci(fib_number);
-    let output = child.wait_with_output().expect("failed to wait on child");
-    let mut cursor = Cursor::new(output.stdout);
-    let mut buf = [0; 4];
-    cursor.read_exact(&mut buf).unwrap();
-    let result = u32::from_le_bytes(buf);
-    assert_eq!(result, value);
+    let fib_number = 25;
+    // Put the desired fib number in the advice tape.
+    machine
+        .cpu_mut()
+        .advice_tape
+        .data
+        .push(Word::from(fib_number));
+
+    // Run the program
+    machine.run(&rom);
+    let output = machine
+        .output()
+        .values
+        .iter()
+        .map(|(_, b)| *b)
+        .collect::<Vec<_>>();
+    assert_eq!(output.len(), 4);
+    let actual_result = u32::from_le_bytes(output.try_into().unwrap());
+
+    let expected_result = fibonacci(fib_number);
+    assert_eq!(actual_result, expected_result);
 }
 
 fn fibonacci(n: u32) -> u32 {

--- a/machine/Cargo.toml
+++ b/machine/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 byteorder = "1.4.3"
 itertools = "0.10.3"

--- a/output/src/lib.rs
+++ b/output/src/lib.rs
@@ -22,6 +22,12 @@ pub struct OutputChip {
     pub values: Vec<(u32, u8)>, // (clk, byte)
 }
 
+impl OutputChip {
+    pub fn bytes(&self) -> Vec<u8> {
+        self.values.iter().map(|(_, b)| *b).collect()
+    }
+}
+
 impl<F, M> Chip<M> for OutputChip
 where
     F: PrimeField,


### PR DESCRIPTION
Previously it was a bit hard to debug, since we couldn't see the child process' stdout when running the test (unless we switch it to `inherit()` temporarily).

It means we can't reuse some code from the bin, so I extracted the most nontrivial part into a shared function `ProgramROM::from_file`.