### PR TITLE
Update assembler to treat jump destinations as byte addressed

### DIFF
--- a/alu_u32/src/add/mod.rs
+++ b/alu_u32/src/add/mod.rs
@@ -140,14 +140,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b + c;
@@ -157,9 +161,7 @@ where
             .add_u32_mut()
             .operations
             .push(Operation::Add32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }

--- a/alu_u32/src/bitwise/mod.rs
+++ b/alu_u32/src/bitwise/mod.rs
@@ -146,14 +146,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b ^ c;
@@ -163,9 +167,7 @@ where
             .bitwise_u32_mut()
             .operations
             .push(Operation::Xor32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }
 
@@ -182,14 +184,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b & c;
@@ -199,9 +205,7 @@ where
             .bitwise_u32_mut()
             .operations
             .push(Operation::And32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }
 
@@ -218,14 +222,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b | c;
@@ -235,8 +243,6 @@ where
             .bitwise_u32_mut()
             .operations
             .push(Operation::And32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }

--- a/alu_u32/src/div/mod.rs
+++ b/alu_u32/src/div/mod.rs
@@ -6,8 +6,8 @@ use columns::{Div32Cols, DIV_COL_MAP, NUM_DIV_COLS};
 use core::mem::transmute;
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
 use valida_machine::core::SDiv;
+use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
 use valida_opcodes::{DIV32, SDIV32};
 use valida_range::MachineWithRangeChip;
 
@@ -88,10 +88,10 @@ impl Div32Chip {
         let cols: &mut Div32Cols<F> = unsafe { transmute(&mut row) };
 
         match op {
-            Operation::Div32(_,_,_) => {
+            Operation::Div32(_, _, _) => {
                 cols.is_div = F::one();
             }
-            Operation::SDiv32(_,_,_) => {
+            Operation::SDiv32(_, _, _) => {
                 cols.is_sdiv = F::one();
             }
         }
@@ -122,14 +122,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b / c;
@@ -139,9 +143,7 @@ where
             .div_u32_mut()
             .operations
             .push(Operation::Div32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }
@@ -160,14 +162,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b.sdiv(c);
@@ -177,9 +183,7 @@ where
             .div_u32_mut()
             .operations
             .push(Operation::SDiv32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }

--- a/alu_u32/src/lt/mod.rs
+++ b/alu_u32/src/lt/mod.rs
@@ -127,14 +127,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let src1 = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let src1 = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let src2 = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let dst = if src1 < src2 {
@@ -148,8 +152,6 @@ where
             .lt_u32_mut()
             .operations
             .push(Operation::Lt32(dst, src1, src2));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }

--- a/alu_u32/src/mul/mod.rs
+++ b/alu_u32/src/mul/mod.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use columns::{Mul32Cols, MUL_COL_MAP, NUM_MUL_COLS};
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word, Mulhs, Mulhu};
+use valida_machine::{instructions, Chip, Instruction, Interaction, Mulhs, Mulhu, Operands, Word};
 use valida_opcodes::{MUL32, MULHS32, MULHU32};
 use valida_range::MachineWithRangeChip;
 
@@ -82,8 +82,11 @@ where
         fields.extend(input_2);
         fields.extend(output);
 
-        let is_real = 
-            VirtualPairCol::sum_main(vec![MUL_COL_MAP.is_mul, MUL_COL_MAP.is_mulhs, MUL_COL_MAP.is_mulhu]);
+        let is_real = VirtualPairCol::sum_main(vec![
+            MUL_COL_MAP.is_mul,
+            MUL_COL_MAP.is_mulhs,
+            MUL_COL_MAP.is_mulhu,
+        ]);
 
         let receive = Interaction {
             fields,
@@ -119,8 +122,8 @@ impl Mul32Chip {
             }
         }
     }
-    
-        fn set_cols<F>(&self, a: &Word<u8>, b: &Word<u8>, c: &Word<u8>, cols: &mut Mul32Cols<F>)
+
+    fn set_cols<F>(&self, a: &Word<u8>, b: &Word<u8>, c: &Word<u8>, cols: &mut Mul32Cols<F>)
     where
         F: PrimeField,
     {
@@ -150,14 +153,19 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c: Word<u8> = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "").into()
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
+                .into()
         };
 
         let a = b * c;
@@ -167,9 +175,7 @@ where
             .mul_u32_mut()
             .operations
             .push(Operation::Mul32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }
@@ -188,14 +194,19 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c: Word<u8> = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "").into()
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
+                .into()
         };
 
         let a = b.mulhs(c);
@@ -205,9 +216,7 @@ where
             .mul_u32_mut()
             .operations
             .push(Operation::Mulhs32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }
@@ -226,14 +235,19 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c: Word<u8> = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "").into()
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
+                .into()
         };
 
         let a = b.mulhu(c);
@@ -243,9 +257,7 @@ where
             .mul_u32_mut()
             .operations
             .push(Operation::Mulhu32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }

--- a/alu_u32/src/shift/mod.rs
+++ b/alu_u32/src/shift/mod.rs
@@ -8,8 +8,8 @@ use columns::{Shift32Cols, COL_MAP, NUM_SHIFT_COLS};
 use core::mem::transmute;
 use valida_bus::{MachineWithGeneralBus, MachineWithRangeBus8};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word, Sra};
-use valida_opcodes::{DIV32, SDIV32, MUL32, SHL32, SHR32, SRA32};
+use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Sra, Word};
+use valida_opcodes::{DIV32, MUL32, SDIV32, SHL32, SHR32, SRA32};
 
 use p3_air::VirtualPairCol;
 use p3_field::PrimeField;
@@ -72,7 +72,8 @@ where
         fields.extend(input_2);
         fields.extend(output);
 
-        let is_real = VirtualPairCol::sum_main(vec![COL_MAP.is_shl, COL_MAP.is_shr, COL_MAP.is_sra]);
+        let is_real =
+            VirtualPairCol::sum_main(vec![COL_MAP.is_shl, COL_MAP.is_shr, COL_MAP.is_sra]);
 
         let send = Interaction {
             fields,
@@ -101,7 +102,8 @@ where
         fields.extend(input_2);
         fields.extend(output);
 
-        let is_real = VirtualPairCol::sum_main(vec![COL_MAP.is_shl, COL_MAP.is_shr, COL_MAP.is_sra]);
+        let is_real =
+            VirtualPairCol::sum_main(vec![COL_MAP.is_shl, COL_MAP.is_shr, COL_MAP.is_sra]);
 
         let receive = Interaction {
             fields,
@@ -180,14 +182,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         // Write the shifted value to memory
@@ -205,9 +211,7 @@ where
             .shift_u32_mut()
             .operations
             .push(Operation::Shl32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }
 
@@ -224,14 +228,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         // Write the shifted value to memory
@@ -249,12 +257,9 @@ where
             .shift_u32_mut()
             .operations
             .push(Operation::Shr32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }
-
 
 impl<M> Instruction<M> for Sra32Instruction
 where
@@ -269,14 +274,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         // Write the shifted value to memory
@@ -294,8 +303,6 @@ where
             .shift_u32_mut()
             .operations
             .push(Operation::Shr32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }

--- a/alu_u32/src/sub/mod.rs
+++ b/alu_u32/src/sub/mod.rs
@@ -136,14 +136,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a = b - c;
@@ -153,9 +157,7 @@ where
             .sub_u32_mut()
             .operations
             .push(Operation::Sub32(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }

--- a/assembler/src/lib.rs
+++ b/assembler/src/lib.rs
@@ -18,7 +18,7 @@ pub fn assemble(input: &str) -> Result<Vec<u8>, String> {
         match pair.as_rule() {
             Rule::label => {
                 let label_name = pair.as_str().trim().trim_end_matches(':');
-                label_locations.insert(label_name, pc);
+                label_locations.insert(label_name, BYTES_PER_INSTR as i32 * pc);
             }
             Rule::instruction => {
                 pc += 1;
@@ -76,7 +76,7 @@ pub fn assemble(input: &str) -> Result<Vec<u8>, String> {
                     "mulhs" | "mulhsi" => MULHS32,
                     "mulhu" | "mulhui" => MULHU32,
                     "div" | "divi" => DIV32,
-                    "sdiv"| "sdivi"=> SDIV32,
+                    "sdiv" | "sdivi" => SDIV32,
                     "lt" | "lti" => LT32,
                     "shl" | "shli" => SHL32,
                     "shr" | "shri" => SHR32,
@@ -115,13 +115,13 @@ pub fn assemble(input: &str) -> Result<Vec<u8>, String> {
                         // (0, 0, 0, 0, 0)
                         operands.extend(vec![0; 5]);
                     }
-                    "add" | "sub" | "mul" | "mulhs" | "mulhu" | "div" | "lt" | "shl" | "shr" | "sra" | "beq" | "bne"
-                    | "and" | "or" | "xor" | "jal" | "jalv" => {
+                    "add" | "sub" | "mul" | "mulhs" | "mulhu" | "div" | "lt" | "shl" | "shr"
+                    | "sra" | "beq" | "bne" | "and" | "or" | "xor" | "jal" | "jalv" => {
                         // (a, b, c, 0, 0)
                         operands.extend(vec![0; 2]);
                     }
-                    "addi" | "subi" | "muli" | "mulhsi" | "mulhui" | "divi" | "sdivi"| "lti" | "shli" | "shri" | "srai" | "beqi"
-                    | "bnei" | "andi" | "ori" | "xori" => {
+                    "addi" | "subi" | "muli" | "mulhsi" | "mulhui" | "divi" | "sdivi" | "lti"
+                    | "shli" | "shri" | "srai" | "beqi" | "bnei" | "andi" | "ori" | "xori" => {
                         // (a, b, c, 0, 1)
                         operands.extend(vec![0, 1]);
                     }

--- a/basic/Cargo.toml
+++ b/basic/Cargo.toml
@@ -19,6 +19,7 @@ valida-cpu = { path = "../cpu" }
 valida-derive = { path = "../derive" }
 valida-machine = { path = "../machine" }
 valida-memory = { path = "../memory" }
+valida-opcodes = { path = "../opcodes" }
 valida-output = { path = "../output" }
 valida-program = { path = "../program" }
 valida-range = { path = "../range" }

--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -25,9 +25,9 @@ fn main() {
 
     let mut machine = BasicMachine::<BabyBear, BabyBear>::default();
     let rom;
-    match ProgramROM::from_file(&args.program){
+    match ProgramROM::from_file(&args.program) {
         Ok(contents) => rom = contents,
-        Err(e) => panic!("Failure to load file: {}. {}",&args.program, e),
+        Err(e) => panic!("Failure to load file: {}. {}", &args.program, e),
     };
     machine.program_mut().set_program_rom(&rom);
     machine.cpu_mut().fp = args.stack_height;

--- a/basic/src/lib.rs
+++ b/basic/src/lib.rs
@@ -10,10 +10,14 @@ use valida_alu_u32::{
         And32Instruction, Bitwise32Chip, MachineWithBitwise32Chip, Or32Instruction,
         Xor32Instruction,
     },
-    div::{Div32Chip, Div32Instruction, SDiv32Instruction, MachineWithDiv32Chip},
+    div::{Div32Chip, Div32Instruction, MachineWithDiv32Chip, SDiv32Instruction},
     lt::{Lt32Chip, Lt32Instruction, MachineWithLt32Chip},
-    mul::{MachineWithMul32Chip, Mul32Chip, Mul32Instruction, Mulhs32Instruction, Mulhu32Instruction},
-    shift::{MachineWithShift32Chip, Shift32Chip, Shl32Instruction, Shr32Instruction, Sra32Instruction},
+    mul::{
+        MachineWithMul32Chip, Mul32Chip, Mul32Instruction, Mulhs32Instruction, Mulhu32Instruction,
+    },
+    shift::{
+        MachineWithShift32Chip, Shift32Chip, Shl32Instruction, Shr32Instruction, Sra32Instruction,
+    },
     sub::{MachineWithSub32Chip, Sub32Chip, Sub32Instruction},
 };
 use valida_bus::{

--- a/basic/tests/test_interpreter.rs
+++ b/basic/tests/test_interpreter.rs
@@ -7,7 +7,6 @@ use valida_machine::{FixedAdviceProvider, Machine, ProgramROM};
 use valida_output::MachineWithOutputChip;
 use valida_program::MachineWithProgramChip;
 
-#[ignore]
 #[test]
 fn run_fibonacci() {
     let mut machine = BasicMachine::<BabyBear, BabyBear>::default();

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -5,13 +5,14 @@ use valida_alu_u32::add::{Add32Instruction, MachineWithAdd32Chip};
 use valida_basic::BasicMachine;
 use valida_cpu::{
     BeqInstruction, BneInstruction, Imm32Instruction, JalInstruction, JalvInstruction,
-    MachineWithCpuChip, StopInstruction, BYTES_PER_INSTR
+    MachineWithCpuChip, StopInstruction,
 };
 use valida_machine::config::StarkConfigImpl;
 use valida_machine::{
     FixedAdviceProvider, Instruction, InstructionWord, Machine, Operands, ProgramROM, Word,
 };
 use valida_memory::MachineWithMemoryChip;
+use valida_opcodes::BYTES_PER_INSTR;
 use valida_program::MachineWithProgramChip;
 
 use p3_challenger::DuplexChallenger;

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -1,11 +1,12 @@
 use crate::columns::{CpuCols, NUM_CPU_COLS};
-use crate::{BYTES_PER_INSTR, CpuChip};
+use crate::CpuChip;
 use core::borrow::Borrow;
 use valida_machine::Word;
 
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField};
 use p3_matrix::MatrixRowSlices;
+use valida_opcodes::BYTES_PER_INSTR;
 
 impl<F> BaseAir<F> for CpuChip {
     fn width(&self) -> usize {
@@ -108,12 +109,19 @@ impl CpuChip {
             local.read_addr_2(),
             reduce::<AB>(base, local.read_value_1()),
         );
-        builder.when(is_store).assert_eq(local.read_addr_2(), addr_b);
+        builder
+            .when(is_store)
+            .assert_eq(local.read_addr_2(), addr_b);
         builder
             .when(is_jalv + (AB::Expr::one() - is_imm_op) * (is_beq + is_bne + is_bus_op))
             .assert_eq(local.read_addr_2(), addr_c);
         builder
-            .when(is_load + is_store + is_jalv + (AB::Expr::one() - is_imm_op) * (is_beq + is_bne + is_bus_op))
+            .when(
+                is_load
+                    + is_store
+                    + is_jalv
+                    + (AB::Expr::one() - is_imm_op) * (is_beq + is_bne + is_bus_op),
+            )
             .assert_one(local.read_2_used());
         builder
             .when(is_jal + is_imm_op * (is_beq + is_bne + is_bus_op))
@@ -123,10 +131,9 @@ impl CpuChip {
         builder
             .when(is_load + is_jal + is_jalv + is_imm32 + is_bus_op)
             .assert_eq(local.write_addr(), addr_a);
-        builder.when(is_store).assert_eq(
-            local.write_addr(),
-            reduce::<AB>(base, local.read_value_2())
-        );
+        builder
+            .when(is_store)
+            .assert_eq(local.write_addr(), reduce::<AB>(base, local.read_value_2()));
         builder.when(is_store).assert_zero(
             local
                 .read_value_1()
@@ -182,11 +189,10 @@ impl CpuChip {
         // Branch manipulation
         let equal = AB::Expr::one() - local.not_equal;
         let next_pc_times_24_if_branching = local.instruction.operands.a();
-        let beq_next_pc_times_24 =
-            equal.clone() * next_pc_times_24_if_branching.clone()
-              + bytes_per_instr_expr.clone() * local.not_equal * incremented_pc.clone();
+        let beq_next_pc_times_24 = equal.clone() * next_pc_times_24_if_branching.clone()
+            + bytes_per_instr_expr.clone() * local.not_equal * incremented_pc.clone();
         let bne_next_pc_times_24 = bytes_per_instr_expr.clone() * equal * incremented_pc
-                                 + local.not_equal * next_pc_times_24_if_branching;
+            + local.not_equal * next_pc_times_24_if_branching;
         builder
             .when_transition()
             .when(local.opcode_flags.is_beq)
@@ -200,13 +206,17 @@ impl CpuChip {
         builder
             .when_transition()
             .when(local.opcode_flags.is_jal)
-            .assert_eq(bytes_per_instr_expr.clone() * next.pc,
-                       local.instruction.operands.b());
+            .assert_eq(
+                bytes_per_instr_expr.clone() * next.pc,
+                local.instruction.operands.b(),
+            );
         builder
             .when_transition()
             .when(local.opcode_flags.is_jalv)
-            .assert_eq(bytes_per_instr_expr.clone() * next.pc,
-                       reduce::<AB>(base, local.read_value_1()));
+            .assert_eq(
+                bytes_per_instr_expr.clone() * next.pc,
+                reduce::<AB>(base, local.read_value_1()),
+            );
     }
 
     fn eval_fp<AB>(

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -62,15 +62,24 @@ impl MemoryChip {
         }
     }
 
-    pub fn read(&mut self, clk: u32, address: u32, log: bool, pc: u32, opcode: u32, ordinal: u32, extra_info: &str) -> Word<u8> {
+    pub fn read(
+        &mut self,
+        clk: u32,
+        address: u32,
+        log: bool,
+        pc: u32,
+        opcode: u32,
+        ordinal: u32,
+        extra_info: &str,
+    ) -> Word<u8> {
         let value = self.cells.get(&address.into()).copied()
           .unwrap_or_else(|| panic!("memory chip: read before write: {} (pc = {}, opcode = {}, ordinal = {}, extra_info = {})", address, pc, opcode, ordinal, extra_info));
-    // pub fn read(&mut self, clk: u32, address: u32, log: bool) -> Word<u8> {
-    //     let value = self
-    //         .cells
-    //         .get(&address.into())
-    //         .copied()
-    //         .unwrap_or_else(|| panic!("Read from uninitialized address {}", address));
+        // pub fn read(&mut self, clk: u32, address: u32, log: bool) -> Word<u8> {
+        //     let value = self
+        //         .cells
+        //         .get(&address.into())
+        //         .copied()
+        //         .unwrap_or_else(|| panic!("Read from uninitialized address {}", address));
         if log {
             self.operations
                 .entry(clk)

--- a/native_field/src/lib.rs
+++ b/native_field/src/lib.rs
@@ -158,14 +158,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a_native = F::from_canonical_u32(b.into()) + F::from_canonical_u32(c.into());
@@ -176,9 +180,7 @@ where
             .native_field_mut()
             .operations
             .push(Operation::Add(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }
@@ -198,14 +200,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a_native = F::from_canonical_u32(b.into()) - F::from_canonical_u32(c.into());
@@ -216,9 +222,7 @@ where
             .native_field_mut()
             .operations
             .push(Operation::Sub(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }
@@ -238,14 +242,18 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         let c = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);
             c
         } else {
             let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
-            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+            state
+                .mem_mut()
+                .read(clk, read_addr_2, true, pc, opcode, 1, "")
         };
 
         let a_m31 = M::F::from_canonical_u32(b.into()) * M::F::from_canonical_u32(c.into());
@@ -256,9 +264,7 @@ where
             .native_field()
             .operations
             .push(Operation::Mul(a, b, c));
-        state
-            .cpu_mut()
-            .push_bus_op(imm, opcode, ops);
+        state.cpu_mut().push_bus_op(imm, opcode, ops);
 
         state.range_check(a);
     }

--- a/opcodes/src/lib.rs
+++ b/opcodes/src/lib.rs
@@ -1,3 +1,5 @@
+pub const BYTES_PER_INSTR: u32 = 24; // 4 bytes per word * 6 words per instruction
+
 /// CORE
 pub const LOAD32: u32 = 1;
 pub const STORE32: u32 = 2;
@@ -16,16 +18,16 @@ pub const ADD32: u32 = 100;
 pub const SUB32: u32 = 101;
 pub const MUL32: u32 = 102;
 pub const DIV32: u32 = 103;
-pub const SDIV32: u32 = 110;
+pub const SDIV32: u32 = 110; // TODO: Should we redo the numbers? Need to update compiler?
 pub const LT32: u32 = 104;
 pub const SHL32: u32 = 105;
 pub const SHR32: u32 = 106;
 pub const AND32: u32 = 107;
 pub const OR32: u32 = 108;
 pub const XOR32: u32 = 109;
-pub const MULHU32 : u32 = 112;
-pub const SRA32 : u32 = 113;
-pub const MULHS32 : u32 =114;
+pub const MULHU32: u32 = 112;
+pub const SRA32: u32 = 113;
+pub const MULHS32: u32 = 114;
 
 /// NATIVE FIELD
 pub const ADD: u32 = 200;

--- a/output/src/lib.rs
+++ b/output/src/lib.rs
@@ -153,15 +153,15 @@ where
         let clk = state.cpu().clock;
         let pc = state.cpu().pc;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
-        let b = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let b = state
+            .mem_mut()
+            .read(clk, read_addr_1, true, pc, opcode, 0, "");
         state
             .output_mut()
             .values
             .push((clk, b.into_iter().last().unwrap()));
 
-        state
-            .cpu_mut()
-            .push_bus_op(None, opcode, ops);
+        state.cpu_mut().push_bus_op(None, opcode, ops);
 
         // The immediate value flag should be set, and the immediate operand value should
         // equal zero. We only write one byte of one word at a time to output.


### PR DESCRIPTION
Fixes `run_fibonacci`.