### PR TITLE
Allow immediate b operand for LT instruction.

### DIFF
--- a/alu_u32/src/lt/mod.rs
+++ b/alu_u32/src/lt/mod.rs
@@ -127,9 +127,15 @@ where
         let mut imm: Option<Word<u8>> = None;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
         let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
-        let src1 = state
-            .mem_mut()
-            .read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let src1 = if ops.d() == 1 {
+            let b = (ops.b() as u32).into();
+            imm = Some(b);
+            b
+        } else {
+            state
+                .mem_mut()
+                .read(clk, read_addr_1, true, pc, opcode, 0, "")
+        };
         let src2 = if ops.is_imm() == 1 {
             let c = (ops.c() as u32).into();
             imm = Some(c);


### PR DESCRIPTION
Before the change, the tests for `ILT` return an error:
```
2024-1-ilt-neg
+ ./llvm-valida/build/bin/clang -c -target delendum ./llvm-test-suite/SingleSource/UnitTests/2024-1-ilt-neg.c -o 2024-1-ilt-neg.o
+ ./llvm-valida/build/bin/ld.lld --script=./llvm-valida/valida.ld -o ./2024-1-ilt-neg.out ./2024-1-ilt-neg.o
+ ./llvm-valida/build/bin/llvm-objcopy -O binary ./2024-1-ilt-neg.out ./2024-1-ilt-neg.out.bin
+ ./valida-mc-fixer/result/bin/valida-mc-fixer ./2024-1-ilt-neg.out.bin ./2024-1-ilt-neg.out.bin.fix
+ ./valida-mc-fixer/result/bin/valida-mc-fixer -d ./2024-1-ilt-neg.out.bin.fix 2024-1-ilt-neg.s
+ echo 'running program'
running program
+ timeout 3 ./valida/target/release/valida ./2024-1-ilt-neg.out.bin.fix
thread 'main' panicked at memory/src/lib.rs:67:30:
memory chip: read before write: 16777226 (pc = 8, opcode = 104, ordinal = 0, extra_info = )
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With the change, the tests are running as expected (when https://github.com/lita-xyz/llvm-valida/pull/52 is merged).