### PR TITLE
Update assembler to treat jump destinations as byte addressed

### DIFF
--- a/assembler/src/lib.rs
+++ b/assembler/src/lib.rs
@@ -18,7 +18,7 @@ pub fn assemble(input: &str) -> Result<Vec<u8>, String> {
         match pair.as_rule() {
             Rule::label => {
                 let label_name = pair.as_str().trim().trim_end_matches(':');
-                label_locations.insert(label_name, pc);
+                label_locations.insert(label_name, BYTES_PER_INSTR as i32 * pc);
             }
             Rule::instruction => {
                 pc += 1;

--- a/basic/Cargo.toml
+++ b/basic/Cargo.toml
@@ -19,6 +19,7 @@ valida-cpu = { path = "../cpu" }
 valida-derive = { path = "../derive" }
 valida-machine = { path = "../machine" }
 valida-memory = { path = "../memory" }
+valida-opcodes = { path = "../opcodes" }
 valida-output = { path = "../output" }
 valida-program = { path = "../program" }
 valida-range = { path = "../range" }

--- a/basic/tests/test_interpreter.rs
+++ b/basic/tests/test_interpreter.rs
@@ -7,7 +7,6 @@ use valida_machine::{FixedAdviceProvider, Machine, ProgramROM};
 use valida_output::MachineWithOutputChip;
 use valida_program::MachineWithProgramChip;
 
-#[ignore]
 #[test]
 fn run_fibonacci() {
     let mut machine = BasicMachine::<BabyBear, BabyBear>::default();

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -5,13 +5,14 @@ use valida_alu_u32::add::{Add32Instruction, MachineWithAdd32Chip};
 use valida_basic::BasicMachine;
 use valida_cpu::{
     BeqInstruction, BneInstruction, Imm32Instruction, JalInstruction, JalvInstruction,
-    MachineWithCpuChip, StopInstruction, BYTES_PER_INSTR,
+    MachineWithCpuChip, StopInstruction,
 };
 use valida_machine::config::StarkConfigImpl;
 use valida_machine::{
     FixedAdviceProvider, Instruction, InstructionWord, Machine, Operands, ProgramROM, Word,
 };
 use valida_memory::MachineWithMemoryChip;
+use valida_opcodes::BYTES_PER_INSTR;
 use valida_program::MachineWithProgramChip;
 
 use p3_challenger::DuplexChallenger;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -14,7 +14,9 @@ use valida_machine::{
     instructions, AdviceProvider, Chip, Instruction, InstructionWord, Interaction, Operands, Word,
 };
 use valida_memory::{MachineWithMemoryChip, Operation as MemoryOperation};
-use valida_opcodes::{BEQ, BNE, IMM32, JAL, JALV, LOAD32, READ_ADVICE, STOP, STORE32};
+use valida_opcodes::{
+    BEQ, BNE, BYTES_PER_INSTR, IMM32, JAL, JALV, LOAD32, READ_ADVICE, STOP, STORE32,
+};
 use valida_util::batch_multiplicative_inverse;
 
 use p3_air::VirtualPairCol;
@@ -55,8 +57,6 @@ pub struct Registers {
     pc: u32,
     fp: u32,
 }
-
-pub const BYTES_PER_INSTR: u32 = 24; // 4 bytes per word * 6 words per instruction
 
 impl<M> Chip<M> for CpuChip
 where

--- a/cpu/src/stark.rs
+++ b/cpu/src/stark.rs
@@ -1,11 +1,12 @@
 use crate::columns::{CpuCols, NUM_CPU_COLS};
-use crate::{CpuChip, BYTES_PER_INSTR};
+use crate::CpuChip;
 use core::borrow::Borrow;
 use valida_machine::Word;
 
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{AbstractField, PrimeField};
 use p3_matrix::MatrixRowSlices;
+use valida_opcodes::BYTES_PER_INSTR;
 
 impl<F> BaseAir<F> for CpuChip {
     fn width(&self) -> usize {

--- a/opcodes/src/lib.rs
+++ b/opcodes/src/lib.rs
@@ -1,3 +1,5 @@
+pub const BYTES_PER_INSTR: u32 = 24; // 4 bytes per word * 6 words per instruction
+
 /// CORE
 pub const LOAD32: u32 = 1;
 pub const STORE32: u32 = 2;
@@ -16,7 +18,7 @@ pub const ADD32: u32 = 100;
 pub const SUB32: u32 = 101;
 pub const MUL32: u32 = 102;
 pub const DIV32: u32 = 103;
-pub const SDIV32: u32 = 110;
+pub const SDIV32: u32 = 110; // TODO: Should we redo the numbers? Need to update compiler?
 pub const LT32: u32 = 104;
 pub const SHL32: u32 = 105;
 pub const SHR32: u32 = 106;


### PR DESCRIPTION
Fixes `run_fibonacci`.