### PR TITLE
Fix padding rows in `Mul32Chip`

### DIFF
--- a/alu_u32/src/mul/mod.rs
+++ b/alu_u32/src/mul/mod.rs
@@ -50,12 +50,10 @@ where
         }
 
         // Encode dummy operations as needed to pad the trace.
-        let dummy_op = Operation::Mul32(Word::default(), Word::default(), Word::default());
         for i in num_ops..num_padded_ops {
             let row = &mut values[i * NUM_MUL_COLS..(i + 1) * NUM_MUL_COLS];
             let cols: &mut Mul32Cols<F> = row.borrow_mut();
             cols.counter = F::from_canonical_usize(i + 1);
-            self.op_to_row(&dummy_op, cols);
         }
 
         RowMajorMatrix {

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -30,7 +30,6 @@ use rand::thread_rng;
 use valida_machine::__internal::p3_commit::ExtensionMmcs;
 
 #[test]
-#[ignore] // TODO: Bus arguments are failing?
 fn prove_fibonacci() {
     let mut program = vec![];
 


### PR DESCRIPTION
Previously padding rows had `is_mul = 1` and `is_real = 0`; the latter had the effect of excluding these rows from the bus argument.

Now inclusion in the bus argument is instead controlled by `is_mul + is_mulhs + is_mulhu`, so padding rows can't have `is_mul = 1` as they did before.

The multiplication constraints should be satisfied on an all-zero row, so I think it's easiest to leave the zeros, except for the `counter` column which must be populated for range checks to work.