### PR TITLE
Better use of generics

### DIFF
--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -23,7 +23,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let mut machine = BasicMachine::<BabyBear, BabyBear>::default();
+    let mut machine = BasicMachine::<BabyBear>::default();
     let rom = match ProgramROM::from_file(&args.program) {
         Ok(contents) => contents,
         Err(e) => panic!("Failure to load file: {}. {}", &args.program, e),

--- a/basic/src/lib.rs
+++ b/basic/src/lib.rs
@@ -3,7 +3,8 @@
 
 extern crate alloc;
 
-use p3_field::TwoAdicField;
+use core::marker::PhantomData;
+use p3_field::{Field, PrimeField32, TwoAdicField};
 use valida_alu_u32::{
     add::{Add32Chip, Add32Instruction, MachineWithAdd32Chip},
     bitwise::{
@@ -39,10 +40,11 @@ use valida_program::{MachineWithProgramChip, ProgramChip};
 use valida_range::{MachineWithRangeChip, RangeCheckerChip};
 
 use p3_maybe_rayon::*;
+use valida_machine::config::StarkConfig;
 
 #[derive(Machine, Default)]
-#[machine_fields(F, EF)]
-pub struct BasicMachine<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> {
+#[machine_fields(F)]
+pub struct BasicMachine<F: PrimeField32 + TwoAdicField> {
     // Core instructions
     #[instruction]
     load32: Load32Instruction,
@@ -122,45 +124,34 @@ pub struct BasicMachine<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> {
     #[chip]
     range: RangeCheckerChip<256>,
 
-    _phantom_base: core::marker::PhantomData<F>,
-    _phantom_extension: core::marker::PhantomData<EF>,
+    _phantom_sc: PhantomData<fn() -> F>,
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithGeneralBus
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithGeneralBus<F> for BasicMachine<F> {
     fn general_bus(&self) -> BusArgument {
         BusArgument::Global(0)
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithProgramBus
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithProgramBus<F> for BasicMachine<F> {
     fn program_bus(&self) -> BusArgument {
         BusArgument::Global(1)
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithMemBus
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithMemBus<F> for BasicMachine<F> {
     fn mem_bus(&self) -> BusArgument {
         BusArgument::Global(2)
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithRangeBus8
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithRangeBus8<F> for BasicMachine<F> {
     fn range_bus(&self) -> BusArgument {
         BusArgument::Global(3)
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithCpuChip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithCpuChip<F> for BasicMachine<F> {
     fn cpu(&self) -> &CpuChip {
         &self.cpu
     }
@@ -170,9 +161,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithCpuChip
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithProgramChip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithProgramChip<F> for BasicMachine<F> {
     fn program(&self) -> &ProgramChip {
         &self.program
     }
@@ -182,9 +171,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithProgramCh
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithMemoryChip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithMemoryChip<F> for BasicMachine<F> {
     fn mem(&self) -> &MemoryChip {
         &self.mem
     }
@@ -194,9 +181,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithMemoryChi
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithAdd32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithAdd32Chip<F> for BasicMachine<F> {
     fn add_u32(&self) -> &Add32Chip {
         &self.add_u32
     }
@@ -206,9 +191,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithAdd32Chip
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithSub32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithSub32Chip<F> for BasicMachine<F> {
     fn sub_u32(&self) -> &Sub32Chip {
         &self.sub_u32
     }
@@ -218,9 +201,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithSub32Chip
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithMul32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithMul32Chip<F> for BasicMachine<F> {
     fn mul_u32(&self) -> &Mul32Chip {
         &self.mul_u32
     }
@@ -230,9 +211,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithMul32Chip
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithDiv32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithDiv32Chip<F> for BasicMachine<F> {
     fn div_u32(&self) -> &Div32Chip {
         &self.div_u32
     }
@@ -242,9 +221,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithDiv32Chip
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithBitwise32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithBitwise32Chip<F> for BasicMachine<F> {
     fn bitwise_u32(&self) -> &Bitwise32Chip {
         &self.bitwise_u32
     }
@@ -254,9 +231,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithBitwise32
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithLt32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithLt32Chip<F> for BasicMachine<F> {
     fn lt_u32(&self) -> &Lt32Chip {
         &self.lt_u32
     }
@@ -266,9 +241,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithLt32Chip
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithShift32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithShift32Chip<F> for BasicMachine<F> {
     fn shift_u32(&self) -> &Shift32Chip {
         &self.shift_u32
     }
@@ -278,9 +251,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithShift32Ch
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithOutputChip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithOutputChip<F> for BasicMachine<F> {
     fn output(&self) -> &OutputChip {
         &self.output
     }
@@ -290,9 +261,7 @@ impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithOutputChi
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithRangeChip<256>
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithRangeChip<F, 256> for BasicMachine<F> {
     fn range(&self) -> &RangeCheckerChip<256> {
         &self.range
     }

--- a/basic/tests/test_interpreter.rs
+++ b/basic/tests/test_interpreter.rs
@@ -9,7 +9,7 @@ use valida_program::MachineWithProgramChip;
 
 #[test]
 fn run_fibonacci() {
-    let mut machine = BasicMachine::<BabyBear, BabyBear>::default();
+    let mut machine = BasicMachine::<BabyBear>::default();
     let asm_path = "tests/programs/assembly/fibonacci.val";
     let asm = read_to_string(asm_path).expect("Failed to read asm");
     let rom = ProgramROM::from_machine_code(&assemble(&asm).unwrap());

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -55,35 +55,35 @@ fn prove_fibonacci() {
     //...
     program.extend([
         InstructionWord {
-            opcode: <Imm32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-4, 0, 0, 0, 0]),
         },
         InstructionWord {
-            opcode: <Imm32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-8, 0, 0, 0, 25]),
         },
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-16, -8, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <Imm32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-20, 0, 0, 0, 28]),
         },
         InstructionWord {
-            opcode: <JalInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <JalInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-28, fib_bb0, -28, 0, 0]),
         },
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-12, -24, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([4, -12, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <StopInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <StopInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands::default(),
         },
     ]);
@@ -97,23 +97,23 @@ fn prove_fibonacci() {
     //	beq	.LBB0_1, 0(fp), 0(fp)
     program.extend([
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-4, 12, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <Imm32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-8, 0, 0, 0, 0]),
         },
         InstructionWord {
-            opcode: <Imm32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-12, 0, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <Imm32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-16, 0, 0, 0, 0]),
         },
         InstructionWord {
-            opcode: <BeqInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <BeqInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([fib_bb0_1, 0, 0, 0, 0]),
         },
     ]);
@@ -123,11 +123,11 @@ fn prove_fibonacci() {
     //	beq	.LBB0_4, 0(fp), 0(fp)
     program.extend([
         InstructionWord {
-            opcode: <BneInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <BneInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([fib_bb0_2, -16, -4, 0, 0]),
         },
         InstructionWord {
-            opcode: <BeqInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <BeqInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([fib_bb0_4, 0, 0, 0, 0]),
         },
     ]);
@@ -139,19 +139,19 @@ fn prove_fibonacci() {
     //	beq	.LBB0_3, 0(fp), 0(fp)
     program.extend([
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-20, -8, -12, 0, 0]),
         },
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-8, -12, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-12, -20, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <BeqInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <BeqInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([fib_bb0_3, 0, 0, 0, 0]),
         },
     ]);
@@ -161,11 +161,11 @@ fn prove_fibonacci() {
     //	beq	.LBB0_1, 0(fp), 0(fp)
     program.extend([
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-16, -16, 1, 0, 1]),
         },
         InstructionWord {
-            opcode: <BeqInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <BeqInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([fib_bb0_1, 0, 0, 0, 0]),
         },
     ]);
@@ -175,16 +175,16 @@ fn prove_fibonacci() {
     //	jalv	-4(fp), 0(fp), 8(fp)
     program.extend([
         InstructionWord {
-            opcode: <Add32Instruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <Add32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([4, -8, 0, 0, 1]),
         },
         InstructionWord {
-            opcode: <JalvInstruction as Instruction<BasicMachine<Val, Challenge>>>::OPCODE,
+            opcode: <JalvInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
             operands: Operands([-4, 0, 8, 0, 0]),
         },
     ]);
 
-    let mut machine = BasicMachine::<Val, Challenge>::default();
+    let mut machine = BasicMachine::<Val>::default();
     let rom = ProgramROM::new(program);
     machine.program_mut().set_program_rom(&rom);
     machine.cpu_mut().fp = 0x1000;

--- a/bus/src/lib.rs
+++ b/bus/src/lib.rs
@@ -1,3 +1,4 @@
+use p3_field::Field;
 use valida_machine::{BusArgument, Machine};
 
 #[derive(Default)]
@@ -6,22 +7,22 @@ pub struct CpuMemBus {}
 #[derive(Default)]
 pub struct SharedCoprocessorBus {}
 
-pub trait MachineWithGeneralBus: Machine {
+pub trait MachineWithGeneralBus<F: Field>: Machine<F> {
     fn general_bus(&self) -> BusArgument;
 }
 
-pub trait MachineWithProgramBus: Machine {
+pub trait MachineWithProgramBus<F: Field>: Machine<F> {
     fn program_bus(&self) -> BusArgument;
 }
 
-pub trait MachineWithMemBus: Machine {
+pub trait MachineWithMemBus<F: Field>: Machine<F> {
     fn mem_bus(&self) -> BusArgument;
 }
 
-pub trait MachineWithRangeBus8: Machine {
+pub trait MachineWithRangeBus8<F: Field>: Machine<F> {
     fn range_bus(&self) -> BusArgument;
 }
 
-pub trait MachineWithPowerOfTwoBus: Machine {
+pub trait MachineWithPowerOfTwoBus<F: Field>: Machine<F> {
     fn power_of_two_bus(&self) -> BusArgument;
 }

--- a/machine/src/__internal/debug_builder.rs
+++ b/machine/src/__internal/debug_builder.rs
@@ -1,70 +1,30 @@
+use crate::config::StarkConfig;
 use crate::{Machine, ValidaAirBuilder};
 use p3_air::{AirBuilder, PairBuilder, PermutationAirBuilder, TwoRowMatrixView};
-use p3_field::{ExtensionField, Field};
+use p3_field::AbstractField;
 
 /// An `AirBuilder` which asserts that each constraint is zero, allowing any failed constraints to
 /// be detected early.
-pub struct DebugConstraintBuilder<'a, F: Field, EF: ExtensionField<F>, M: Machine> {
+pub struct DebugConstraintBuilder<'a, M: Machine<SC::Val>, SC: StarkConfig> {
     pub(crate) machine: &'a M,
-    pub(crate) main: TwoRowMatrixView<'a, F>,
-    pub(crate) preprocessed: TwoRowMatrixView<'a, F>,
-    pub(crate) perm: TwoRowMatrixView<'a, EF>,
-    pub(crate) perm_challenges: &'a [EF],
-    pub(crate) is_first_row: F,
-    pub(crate) is_last_row: F,
-    pub(crate) is_transition: F,
+    pub(crate) main: TwoRowMatrixView<'a, SC::Val>,
+    pub(crate) preprocessed: TwoRowMatrixView<'a, SC::Val>,
+    pub(crate) perm: TwoRowMatrixView<'a, SC::Challenge>,
+    pub(crate) perm_challenges: &'a [SC::Challenge],
+    pub(crate) is_first_row: SC::Val,
+    pub(crate) is_last_row: SC::Val,
+    pub(crate) is_transition: SC::Val,
 }
 
-impl<'a, F, EF, M> PermutationAirBuilder for DebugConstraintBuilder<'a, F, EF, M>
+impl<'a, M, SC> AirBuilder for DebugConstraintBuilder<'a, M, SC>
 where
-    F: Field,
-    EF: ExtensionField<F>,
-    M: Machine<EF = EF>,
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
 {
-    type EF = M::EF;
-    type VarEF = M::EF;
-    type ExprEF = M::EF;
-    type MP = TwoRowMatrixView<'a, EF>;
-
-    fn permutation(&self) -> Self::MP {
-        self.perm
-    }
-
-    fn permutation_randomness(&self) -> &[Self::EF] {
-        // TODO: implement
-        self.perm_challenges
-    }
-}
-
-impl<'a, F, EF, M> PairBuilder for DebugConstraintBuilder<'a, F, EF, M>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    M: Machine<EF = EF>,
-{
-    fn preprocessed(&self) -> Self::M {
-        self.preprocessed
-    }
-}
-
-impl<'a, M: Machine> ValidaAirBuilder for DebugConstraintBuilder<'a, M::F, M::EF, M> {
-    type Machine = M;
-
-    fn machine(&self) -> &Self::Machine {
-        self.machine
-    }
-}
-
-impl<'a, F, EF, M> AirBuilder for DebugConstraintBuilder<'a, F, EF, M>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    M: Machine,
-{
-    type F = F;
-    type Expr = F;
-    type Var = F;
-    type M = TwoRowMatrixView<'a, F>;
+    type F = SC::Val;
+    type Expr = SC::Val;
+    type Var = SC::Val;
+    type M = TwoRowMatrixView<'a, SC::Val>;
 
     fn is_first_row(&self) -> Self::Expr {
         self.is_first_row
@@ -87,6 +47,51 @@ where
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
-        assert_eq!(x.into(), F::zero(), "constraints must evaluate to zero");
+        assert_eq!(
+            x.into(),
+            SC::Val::zero(),
+            "constraints must evaluate to zero"
+        );
+    }
+}
+
+impl<'a, M, SC> PairBuilder for DebugConstraintBuilder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    fn preprocessed(&self) -> Self::M {
+        self.preprocessed
+    }
+}
+
+impl<'a, M, SC> PermutationAirBuilder for DebugConstraintBuilder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    type EF = SC::Challenge;
+    type VarEF = SC::Challenge;
+    type ExprEF = SC::Challenge;
+    type MP = TwoRowMatrixView<'a, SC::Challenge>;
+
+    fn permutation(&self) -> Self::MP {
+        self.perm
+    }
+
+    fn permutation_randomness(&self) -> &[Self::EF] {
+        self.perm_challenges
+    }
+}
+
+impl<'a, M: Machine<SC::Val>, SC> ValidaAirBuilder for DebugConstraintBuilder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    type Machine = M;
+
+    fn machine(&self) -> &Self::Machine {
+        self.machine
     }
 }

--- a/machine/src/__internal/folding_builder.rs
+++ b/machine/src/__internal/folding_builder.rs
@@ -1,68 +1,27 @@
 use crate::{Machine, ValidaAirBuilder};
 use p3_air::{AirBuilder, PairBuilder, PermutationAirBuilder, TwoRowMatrixView};
-use p3_field::{ExtensionField, Field};
+use valida_machine::config::StarkConfig;
 
-pub struct ConstraintFolder<'a, F: Field, EF: ExtensionField<F>, M: Machine> {
+pub struct ConstraintFolder<'a, M: Machine<SC::Val>, SC: StarkConfig> {
     pub(crate) machine: &'a M,
-    pub(crate) main: TwoRowMatrixView<'a, F>,
-    pub(crate) preprocessed: TwoRowMatrixView<'a, F>,
-    pub(crate) perm: TwoRowMatrixView<'a, EF>,
-    pub(crate) rand_elems: &'a [EF],
-    pub(crate) is_first_row: F,
-    pub(crate) is_last_row: F,
-    pub(crate) is_transition: F,
+    pub(crate) main: TwoRowMatrixView<'a, SC::Val>,
+    pub(crate) preprocessed: TwoRowMatrixView<'a, SC::Val>,
+    pub(crate) perm: TwoRowMatrixView<'a, SC::Challenge>,
+    pub(crate) rand_elems: &'a [SC::Challenge],
+    pub(crate) is_first_row: SC::Val,
+    pub(crate) is_last_row: SC::Val,
+    pub(crate) is_transition: SC::Val,
 }
 
-impl<'a, F, EF, M> PermutationAirBuilder for ConstraintFolder<'a, F, EF, M>
+impl<'a, M, SC> AirBuilder for ConstraintFolder<'a, M, SC>
 where
-    F: Field,
-    EF: ExtensionField<F>,
-    M: Machine<EF = EF>,
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
 {
-    type EF = M::EF;
-    type VarEF = M::EF;
-    type ExprEF = M::EF;
-    type MP = TwoRowMatrixView<'a, EF>;
-
-    fn permutation(&self) -> Self::MP {
-        self.perm
-    }
-
-    fn permutation_randomness(&self) -> &[Self::EF] {
-        // TODO: implement
-        self.rand_elems
-    }
-}
-
-impl<'a, F, EF, M> PairBuilder for ConstraintFolder<'a, F, EF, M>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    M: Machine<EF = EF>,
-{
-    fn preprocessed(&self) -> Self::M {
-        self.preprocessed
-    }
-}
-
-impl<'a, M: Machine> ValidaAirBuilder for ConstraintFolder<'a, M::F, M::EF, M> {
-    type Machine = M;
-
-    fn machine(&self) -> &Self::Machine {
-        self.machine
-    }
-}
-
-impl<'a, F, EF, M> AirBuilder for ConstraintFolder<'a, F, EF, M>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    M: Machine,
-{
-    type F = F;
-    type Expr = F;
-    type Var = F;
-    type M = TwoRowMatrixView<'a, F>;
+    type F = SC::Val;
+    type Expr = SC::Val; // TODO: PackedVal
+    type Var = SC::Val; // TODO: PackedVal
+    type M = TwoRowMatrixView<'a, SC::Val>; // TODO: PackedVal
 
     fn is_first_row(&self) -> Self::Expr {
         self.is_first_row
@@ -86,5 +45,47 @@ where
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, _x: I) {
         // TODO
+    }
+}
+
+impl<'a, M, SC> PairBuilder for ConstraintFolder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    fn preprocessed(&self) -> Self::M {
+        self.preprocessed
+    }
+}
+
+impl<'a, M, SC> PermutationAirBuilder for ConstraintFolder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    type EF = SC::Challenge;
+    type VarEF = SC::Challenge;
+    type ExprEF = SC::Challenge;
+    type MP = TwoRowMatrixView<'a, SC::Challenge>; // TODO: packed challenge?
+
+    fn permutation(&self) -> Self::MP {
+        self.perm
+    }
+
+    fn permutation_randomness(&self) -> &[Self::EF] {
+        // TODO: implement
+        self.rand_elems
+    }
+}
+
+impl<'a, M, SC> ValidaAirBuilder for ConstraintFolder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    type Machine = M;
+
+    fn machine(&self) -> &Self::Machine {
+        self.machine
     }
 }

--- a/machine/src/__internal/prove.rs
+++ b/machine/src/__internal/prove.rs
@@ -1,8 +1,6 @@
-use crate::__internal::ConstraintFolder;
 use crate::config::StarkConfig;
 use crate::proof::ChipProof;
 use crate::{Chip, Machine};
-use p3_air::Air;
 
 pub fn prove<M, A, SC>(
     _machine: &M,
@@ -11,9 +9,9 @@ pub fn prove<M, A, SC>(
     _challenger: &mut SC::Challenger,
 ) -> ChipProof
 where
-    M: Machine,
-    A: for<'a> Air<ConstraintFolder<'a, M::F, M::EF, M>> + Chip<M>,
-    SC: StarkConfig<Val = M::F, Challenge = M::EF>,
+    M: Machine<SC::Val>,
+    A: Chip<M, SC>,
+    SC: StarkConfig,
 {
     // TODO: Sumcheck
     ChipProof

--- a/machine/src/config.rs
+++ b/machine/src/config.rs
@@ -1,12 +1,12 @@
 use core::marker::PhantomData;
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, UnivariatePcsWithLde};
-use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField, TwoAdicField};
+use p3_field::{AbstractExtensionField, ExtensionField, PackedField, PrimeField32, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 
 pub trait StarkConfig {
     /// The field over which trace data is encoded.
-    type Val: Field;
+    type Val: PrimeField32 + TwoAdicField; // TODO: Relax to Field?
     type PackedVal: PackedField<Scalar = Self::Val>;
 
     /// The field from which most random challenges are drawn.
@@ -51,7 +51,7 @@ impl<Val, Challenge, PackedChallenge, Pcs, Challenger>
 impl<Val, Challenge, PackedChallenge, Pcs, Challenger> StarkConfig
     for StarkConfigImpl<Val, Challenge, PackedChallenge, Pcs, Challenger>
 where
-    Val: Field,
+    Val: PrimeField32 + TwoAdicField, // TODO: Relax to Field?
     Challenge: ExtensionField<Val> + TwoAdicField,
     PackedChallenge: AbstractExtensionField<Val::Packing, F = Challenge>,
     Pcs: UnivariatePcsWithLde<Val, Challenge, RowMajorMatrix<Val>, Challenger>,

--- a/output/src/lib.rs
+++ b/output/src/lib.rs
@@ -9,9 +9,10 @@ use valida_machine::{
 use valida_opcodes::WRITE;
 
 use p3_air::VirtualPairCol;
-use p3_field::PrimeField;
+use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::*;
+use valida_machine::config::StarkConfig;
 use valida_util::pad_to_power_of_two;
 
 pub mod columns;
@@ -28,12 +29,12 @@ impl OutputChip {
     }
 }
 
-impl<F, M> Chip<M> for OutputChip
+impl<M, SC> Chip<M, SC> for OutputChip
 where
-    F: PrimeField,
-    M: MachineWithGeneralBus<F = F>,
+    M: MachineWithGeneralBus<SC::Val>,
+    SC: StarkConfig,
 {
-    fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<M::F> {
+    fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let table_len = self.values.len() as u32;
         let mut rows = self
             .values
@@ -47,15 +48,15 @@ where
                 let num_rows = (clk_diff / table_len) as usize + 1;
                 let mut rows = Vec::with_capacity(num_rows);
                 for n in 0..num_rows {
-                    let mut row = [M::F::zero(); NUM_OUTPUT_COLS];
-                    let cols: &mut OutputCols<M::F> = unsafe { transmute(&mut row) };
+                    let mut row = [SC::Val::zero(); NUM_OUTPUT_COLS];
+                    let cols: &mut OutputCols<SC::Val> = unsafe { transmute(&mut row) };
                     if n == 0 {
-                        cols.is_real = M::F::one();
-                        cols.clk = M::F::from_canonical_u32(clk_1);
-                        cols.value = M::F::from_canonical_u8(val_1);
+                        cols.is_real = SC::Val::one();
+                        cols.clk = SC::Val::from_canonical_u32(clk_1);
+                        cols.value = SC::Val::from_canonical_u8(val_1);
                     } else {
                         // Dummy output to satisfy range check
-                        cols.clk = M::F::from_canonical_u32(clk_1 + table_len * (n + 1) as u32);
+                        cols.clk = SC::Val::from_canonical_u32(clk_1 + table_len * (n + 1) as u32);
                     }
                     rows.push(row);
                 }
@@ -63,12 +64,12 @@ where
                 // Compute clock diffs
                 rows.iter()
                     .map(|row| row[OUTPUT_COL_MAP.clk])
-                    .chain(iter::once(M::F::from_canonical_u32(clk_2)))
+                    .chain(iter::once(SC::Val::from_canonical_u32(clk_2)))
                     .collect::<Vec<_>>()
                     .windows(2)
                     .enumerate()
                     .for_each(|(n, clks)| {
-                        let cols: &mut OutputCols<M::F> = unsafe { transmute(&mut rows[n]) };
+                        let cols: &mut OutputCols<SC::Val> = unsafe { transmute(&mut rows[n]) };
                         cols.diff = clks[1] - clks[0];
                     });
 
@@ -79,11 +80,11 @@ where
 
         // Add final row
         if let Some(last_row) = self.values.last() {
-            let mut row = [M::F::zero(); NUM_OUTPUT_COLS];
-            let cols: &mut OutputCols<M::F> = unsafe { transmute(&mut row) };
-            cols.is_real = M::F::one();
-            cols.clk = M::F::from_canonical_u32(last_row.0);
-            cols.value = M::F::from_canonical_u8(last_row.1);
+            let mut row = [SC::Val::zero(); NUM_OUTPUT_COLS];
+            let cols: &mut OutputCols<SC::Val> = unsafe { transmute(&mut row) };
+            cols.is_real = SC::Val::one();
+            cols.clk = SC::Val::from_canonical_u32(last_row.0);
+            cols.value = SC::Val::from_canonical_u8(last_row.1);
             rows.push(row);
         }
 
@@ -91,11 +92,11 @@ where
         // re-enable local_sends and local_receives
 
         let mut values = rows.concat();
-        pad_to_power_of_two::<NUM_OUTPUT_COLS, F>(&mut values);
+        pad_to_power_of_two::<NUM_OUTPUT_COLS, SC::Val>(&mut values);
         RowMajorMatrix::new(values, NUM_OUTPUT_COLS)
     }
 
-    //fn local_sends(&self) -> Vec<Interaction<M::F>> {
+    //fn local_sends(&self) -> Vec<Interaction<SC::Val>> {
     //    let sends = Interaction {
     //        fields: vec![VirtualPairCol::single_main(OUTPUT_COL_MAP.diff)],
     //        count: VirtualPairCol::one(),
@@ -104,7 +105,7 @@ where
     //    vec![sends]
     //}
 
-    //fn local_receives(&self) -> Vec<Interaction<M::F>> {
+    //fn local_receives(&self) -> Vec<Interaction<SC::Val>> {
     //    let receives = Interaction {
     //        fields: vec![VirtualPairCol::single_main(OUTPUT_COL_MAP.counter)],
     //        count: VirtualPairCol::single_main(OUTPUT_COL_MAP.counter_mult),
@@ -113,12 +114,12 @@ where
     //    vec![receives]
     //}
 
-    fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
+    fn global_receives(&self, machine: &M) -> Vec<Interaction<SC::Val>> {
         let opcode = VirtualPairCol::single_main(OUTPUT_COL_MAP.opcode);
         let clk = VirtualPairCol::single_main(OUTPUT_COL_MAP.clk);
 
         let mut values = (0..CPU_MEMORY_CHANNELS * MEMORY_CELL_BYTES)
-            .map(|_| VirtualPairCol::constant(M::F::zero()))
+            .map(|_| VirtualPairCol::constant(SC::Val::zero()))
             .collect::<Vec<_>>();
         values[MEMORY_CELL_BYTES - 1] = VirtualPairCol::single_main(OUTPUT_COL_MAP.value);
 
@@ -135,21 +136,22 @@ where
     }
 }
 
-pub trait MachineWithOutputChip: MachineWithCpuChip {
+pub trait MachineWithOutputChip<F: Field>: MachineWithCpuChip<F> {
     fn output(&self) -> &OutputChip;
     fn output_mut(&mut self) -> &mut OutputChip;
 }
 
 instructions!(WriteInstruction);
 
-impl<M> Instruction<M> for WriteInstruction
+impl<M, F> Instruction<M, F> for WriteInstruction
 where
-    M: MachineWithOutputChip,
+    M: MachineWithOutputChip<F>,
+    F: Field,
 {
     const OPCODE: u32 = WRITE;
 
     fn execute(state: &mut M, ops: Operands<i32>) {
-        let opcode = <Self as Instruction<M>>::OPCODE;
+        let opcode = <Self as Instruction<M, F>>::OPCODE;
         let clk = state.cpu().clock;
         let pc = state.cpu().pc;
         let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;

--- a/program/src/stark.rs
+++ b/program/src/stark.rs
@@ -4,18 +4,17 @@ use alloc::vec;
 use valida_machine::InstructionWord;
 
 use p3_air::{Air, BaseAir, PairBuilder};
-use p3_field::PrimeField64;
+use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 
-impl<F, AB> Air<AB> for ProgramChip
+impl<AB> Air<AB> for ProgramChip
 where
-    F: PrimeField64,
-    AB: PairBuilder<F = F>,
+    AB: PairBuilder,
 {
     fn eval(&self, _builder: &mut AB) {}
 }
 
-impl<F: PrimeField64> BaseAir<F> for ProgramChip {
+impl<F: Field> BaseAir<F> for ProgramChip {
     fn width(&self) -> usize {
         NUM_PROGRAM_COLS
     }

--- a/range/src/lib.rs
+++ b/range/src/lib.rs
@@ -9,10 +9,12 @@ use columns::{RangeCols, NUM_RANGE_COLS, RANGE_COL_MAP};
 use core::mem::transmute;
 use valida_bus::MachineWithRangeBus8;
 use valida_machine::Interaction;
-use valida_machine::{Chip, Machine, PrimeField, Word};
+use valida_machine::{Chip, Machine, Word};
 
 use p3_air::VirtualPairCol;
+use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
+use valida_machine::config::StarkConfig;
 
 pub mod columns;
 pub mod stark;
@@ -22,26 +24,26 @@ pub struct RangeCheckerChip<const MAX: u32> {
     pub count: BTreeMap<u32, u32>,
 }
 
-impl<F, M, const MAX: u32> Chip<M> for RangeCheckerChip<MAX>
+impl<M, SC, const MAX: u32> Chip<M, SC> for RangeCheckerChip<MAX>
 where
-    F: PrimeField,
-    M: MachineWithRangeBus8<F = F>,
+    M: MachineWithRangeBus8<SC::Val>,
+    SC: StarkConfig,
 {
-    fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<M::F> {
-        let mut rows = vec![[F::zero(); NUM_RANGE_COLS]; MAX as usize];
+    fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
+        let mut rows = vec![[SC::Val::zero(); NUM_RANGE_COLS]; MAX as usize];
         for (n, row) in rows.iter_mut().enumerate() {
-            let cols: &mut RangeCols<F> = unsafe { transmute(row) };
+            let cols: &mut RangeCols<SC::Val> = unsafe { transmute(row) };
             // FIXME: This is very inefficient when the range is large.
             // Iterate over key/val pairs instead in a separate loop.
             if let Some(c) = self.count.get(&(n as u32)) {
-                cols.mult = M::F::from_canonical_u32(*c);
+                cols.mult = SC::Val::from_canonical_u32(*c);
             }
-            cols.counter = M::F::from_canonical_u32(n as u32);
+            cols.counter = SC::Val::from_canonical_u32(n as u32);
         }
         RowMajorMatrix::new(rows.concat(), NUM_RANGE_COLS)
     }
 
-    fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
+    fn global_receives(&self, machine: &M) -> Vec<Interaction<SC::Val>> {
         let input = VirtualPairCol::single_main(RANGE_COL_MAP.counter);
 
         let receive = Interaction {
@@ -53,7 +55,7 @@ where
     }
 }
 
-pub trait MachineWithRangeChip<const MAX: u32>: Machine {
+pub trait MachineWithRangeChip<F: Field, const MAX: u32>: Machine<F> {
     fn range(&self) -> &RangeCheckerChip<MAX>;
     fn range_mut(&mut self) -> &mut RangeCheckerChip<MAX>;
 


### PR DESCRIPTION
This addresses some limitations that were getting in the way of finishing the prover.

- Removes `FE` from `Machine` - it's not really inherent to the machine, and we have it in `StarkConfig`.
- Give `Instruction` a `F: Field` generic, so we can have instructions which only support certain fields.
- Give `Chip` a `SC: StarkConfig` generic, so we can have chips which only support certain fields etc. (I think ideally it would be `F: Field` as above rather than `SC: StarkConfig`, but Rust doesn't support bounds like `Chip<...>: for<'a> for<SC> Air<ConstraintFolder<'a, M, SC>>`.)