### PR TITLE
Add `NE` and `EQ` instructions

### DIFF
--- a/alu_u32/src/com/columns.rs
+++ b/alu_u32/src/com/columns.rs
@@ -9,15 +9,20 @@ pub struct Com32Cols<T> {
     pub input_1: Word<T>,
     pub input_2: Word<T>,
 
-    /// Boolean flags indicating which byte pair differs
-    pub byte_flag: [T; 3],
-
-    /// Bit decomposition of 256 + input_1 - input_2
-    pub bits: [T; 10],
+    /// When doing an equality test between two words, `x` and `y`, this holds the sum of
+    /// `(x_i - y_i)^2`, which is zero if and only if `x = y`.
+    pub diff: T,
+    /// The inverse of `diff`, or undefined if `diff = 0`.
+    pub diff_inv: T,
+    /// A boolean flag indicating whether `diff != 0`.
+    pub not_equal: T,
 
     pub output: T,
 
-    pub multiplicity: T,
+    pub is_ne: T,
+    pub is_eq: T,
+    pub is_ne: T,
+    pub is_eq: T,
 }
 
 pub const NUM_COM_COLS: usize = size_of::<Com32Cols<u8>>();

--- a/alu_u32/src/com/columns.rs
+++ b/alu_u32/src/com/columns.rs
@@ -1,0 +1,29 @@
+use core::borrow::{Borrow, BorrowMut};
+use core::mem::{size_of, transmute};
+use valida_derive::AlignedBorrow;
+use valida_machine::Word;
+use valida_util::indices_arr;
+
+#[derive(AlignedBorrow, Default)]
+pub struct Com32Cols<T> {
+    pub input_1: Word<T>,
+    pub input_2: Word<T>,
+
+    /// Boolean flags indicating which byte pair differs
+    pub byte_flag: [T; 3],
+
+    /// Bit decomposition of 256 + input_1 - input_2
+    pub bits: [T; 10],
+
+    pub output: T,
+
+    pub multiplicity: T,
+}
+
+pub const NUM_COM_COLS: usize = size_of::<Com32Cols<u8>>();
+pub const COM_COL_MAP: Com32Cols<usize> = make_col_map();
+
+const fn make_col_map() -> Com32Cols<usize> {
+    let indices_arr = indices_arr::<NUM_COM_COLS>();
+    unsafe { transmute::<[usize; NUM_COM_COLS], Com32Cols<usize>>(indices_arr) }
+}

--- a/alu_u32/src/com/columns.rs
+++ b/alu_u32/src/com/columns.rs
@@ -21,8 +21,6 @@ pub struct Com32Cols<T> {
 
     pub is_ne: T,
     pub is_eq: T,
-    pub is_ne: T,
-    pub is_eq: T,
 }
 
 pub const NUM_COM_COLS: usize = size_of::<Com32Cols<u8>>();

--- a/alu_u32/src/com/mod.rs
+++ b/alu_u32/src/com/mod.rs
@@ -7,7 +7,7 @@ use core::iter;
 use core::mem::transmute;
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::config::StarkConfig;
+use valida_machine::StarkConfig;
 use valida_machine::{
     instructions, Chip, Instruction, Interaction, Operands, Word, MEMORY_CELL_BYTES,
 };
@@ -16,7 +16,8 @@ use valida_opcodes::{EQ32, NE32};
 use p3_air::VirtualPairCol;
 use p3_field::{AbstractField, Field, PrimeField};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_maybe_rayon::*;
+// use p3_maybe_rayon::*;
+use p3_maybe_rayon::prelude::IntoParallelRefIterator;
 use valida_util::pad_to_power_of_two;
 
 pub mod columns;

--- a/alu_u32/src/com/mod.rs
+++ b/alu_u32/src/com/mod.rs
@@ -1,0 +1,155 @@
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use columns::{Com32Cols, COM_COL_MAP, NUM_COM_COLS};
+use core::iter;
+use core::mem::transmute;
+use valida_bus::MachineWithGeneralBus;
+use valida_cpu::MachineWithCpuChip;
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Operands, Word, MEMORY_CELL_BYTES,
+};
+use valida_opcodes::NE32;
+
+use p3_air::VirtualPairCol;
+use p3_field::PrimeField;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::*;
+use valida_util::pad_to_power_of_two;
+
+pub mod columns;
+pub mod stark;
+
+#[derive(Clone)]
+pub enum Operation {
+    Ne32(Word<u8>, Word<u8>, Word<u8>), // (dst, src1, src2)
+}
+
+#[derive(Default)]
+pub struct Com32Chip {
+    pub operations: Vec<Operation>,
+}
+
+impl<F, M> Chip<M> for Com32Chip
+where
+    F: PrimeField,
+    M: MachineWithGeneralBus<F = F>,
+{
+    fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<M::F> {
+        let rows = self
+            .operations
+            .par_iter()
+            .map(|op| self.op_to_row(op))
+            .collect::<Vec<_>>();
+
+        let mut trace =
+            RowMajorMatrix::new(rows.into_iter().flatten().collect::<Vec<_>>(), NUM_COM_COLS);
+
+        pad_to_power_of_two::<NUM_COM_COLS, F>(&mut trace.values);
+
+        trace
+    }
+
+    fn global_receives(&self, machine: &M) -> Vec<Interaction<M::F>> {
+        let opcode = VirtualPairCol::constant(M::F::from_canonical_u32(NE32));
+        let input_1 = COM_COL_MAP.input_1.0.map(VirtualPairCol::single_main);
+        let input_2 = COM_COL_MAP.input_2.0.map(VirtualPairCol::single_main);
+        let output = (0..MEMORY_CELL_BYTES - 1)
+            .map(|_| VirtualPairCol::constant(M::F::zero()))
+            .chain(iter::once(VirtualPairCol::single_main(COM_COL_MAP.output)));
+
+        let mut fields = vec![opcode];
+        fields.extend(input_1);
+        fields.extend(input_2);
+        fields.extend(output);
+
+        let receive = Interaction {
+            fields,
+            count: VirtualPairCol::single_main(COM_COL_MAP.multiplicity),
+            argument_index: machine.general_bus(),
+        };
+        vec![receive]
+    }
+}
+
+impl Com32Chip {
+    fn op_to_row<F>(&self, op: &Operation) -> [F; NUM_COM_COLS]
+    where
+        F: PrimeField,
+    {
+        let mut row = [F::zero(); NUM_COM_COLS];
+        let cols: &mut Com32Cols<F> = unsafe { transmute(&mut row) };
+
+        match op {
+            Operation::Ne32(dst, src1, src2) => {
+                if let Some(n) = src1
+                    .into_iter()
+                    .zip(src2.into_iter())
+                    .enumerate()
+                    .find_map(|(n, (x, y))| if x == y { Some(n) } else { None })
+                {
+                    let z = 256u16 + src1[n] as u16 - src2[n] as u16;
+                    for i in 0..10 {
+                        cols.bits[i] = F::from_canonical_u16(z >> i & 1);
+                    }
+                    if n < 3 {
+                        cols.byte_flag[n] = F::one();
+                    }
+                }
+                cols.input_1 = src1.transform(F::from_canonical_u8);
+                cols.input_2 = src2.transform(F::from_canonical_u8);
+                cols.output = F::from_canonical_u8(dst[3]);
+                cols.multiplicity = F::one();
+            }
+        }
+        row
+    }
+}
+
+pub trait MachineWithCom32Chip: MachineWithCpuChip {
+    fn com_u32(&self) -> &Com32Chip;
+    fn com_u32_mut(&mut self) -> &mut Com32Chip;
+}
+
+instructions!(Ne32Instruction);
+
+impl<M> Instruction<M> for Ne32Instruction
+where
+    M: MachineWithCom32Chip,
+{
+    const OPCODE: u32 = NE32;
+
+    fn execute(state: &mut M, ops: Operands<i32>) {
+        let opcode = <Self as Instruction<M>>::OPCODE;
+        let clk = state.cpu().clock;
+        let pc = state.cpu().pc;
+        let mut imm: Option<Word<u8>> = None;
+        let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
+        let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
+        let src1 = state.mem_mut().read(clk, read_addr_1, true, pc, opcode, 0, "");
+        let src2 = if ops.is_imm() == 1 {
+            let c = (ops.c() as u32).into();
+            imm = Some(c);
+            c
+        } else {
+            let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
+            state.mem_mut().read(clk, read_addr_2, true, pc, opcode, 1, "")
+        };
+
+        let dst = if src1 != src2 {
+            Word::from(1)
+        } else {
+            Word::from(0)
+        };
+        state.mem_mut().write(clk, write_addr, dst, true);
+
+        state
+            .com_u32_mut()
+            .operations
+            .push(Operation::Ne32(dst, src1, src2));
+        state
+            .cpu_mut()
+            .push_bus_op(imm, opcode, ops);
+    }
+}

--- a/alu_u32/src/com/stark.rs
+++ b/alu_u32/src/com/stark.rs
@@ -30,7 +30,7 @@ where
                 .input_1
                 .into_iter()
                 .zip(local.input_2)
-                .map(|(a, b)| (a - b) * (a - b))
+                .map(|(a, b)| (a - b).square())
                 .sum::<AB::Expr>(),
         );
         builder.assert_bool(local.not_equal);
@@ -40,7 +40,9 @@ where
         builder.assert_bool(local.is_eq);
         builder.assert_bool(local.is_ne + local.is_eq);
 
-        builder.when(local.is_ne).assert_one(local.not_equal);
-        builder.when(local.is_eq).assert_zero(local.not_equal);
+        builder.assert_eq(
+            local.output,
+            local.is_ne * local.not_equal + local.is_eq * (AB::Expr::one() - local.not_equal),
+        )
     }
 }

--- a/alu_u32/src/com/stark.rs
+++ b/alu_u32/src/com/stark.rs
@@ -1,0 +1,72 @@
+use super::columns::Com32Cols;
+use super::Com32Chip;
+use core::borrow::Borrow;
+
+use crate::com::columns::NUM_COM_COLS;
+use p3_air::{Air, AirBuilder, BaseAir};
+use p3_field::AbstractField;
+use p3_matrix::MatrixRowSlices;
+
+impl<F> BaseAir<F> for Com32Chip {
+    fn width(&self) -> usize {
+        NUM_COM_COLS
+    }
+}
+
+impl<F, AB> Air<AB> for Com32Chip
+where
+    F: AbstractField,
+    AB: AirBuilder<F = F>,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local: &Com32Cols<AB::Var> = main.row_slice(0).borrow();
+
+        let base_2 = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512].map(AB::Expr::from_canonical_u32);
+
+        let bit_comp: AB::Expr = local
+            .bits
+            .into_iter()
+            .zip(base_2.iter().cloned())
+            .map(|(bit, base)| bit * base)
+            .sum();
+
+        // Check bit decomposition of z = 256 + input_1[n] - input_2[n], where
+        // n is the most significant byte that differs between inputs
+        for i in 0..3 {
+            builder
+                .when_ne(local.byte_flag[i], AB::Expr::one())
+                .assert_eq(local.input_1[i], local.input_2[i]);
+
+            builder.when(local.byte_flag[i]).assert_eq(
+                AB::Expr::from_canonical_u32(256) + local.input_1[i] - local.input_2[i],
+                bit_comp.clone(),
+            );
+
+            builder.assert_bool(local.byte_flag[i]);
+        }
+
+        // Check final byte (if no other byte flags were set)
+        let flag_sum = local.byte_flag[0] + local.byte_flag[1] + local.byte_flag[2];
+        builder.assert_bool(flag_sum.clone());
+        builder
+            .when_ne(local.multiplicity, AB::Expr::zero())
+            .when_ne(flag_sum, AB::Expr::one())
+            .assert_eq(
+                AB::Expr::from_canonical_u32(256) + local.input_1[3] - local.input_2[3],
+                bit_comp.clone(),
+            );
+
+        // Output constraints
+        builder.when(local.bits[8]).assert_zero(local.output);
+        builder
+            .when_ne(local.multiplicity, AB::Expr::zero())
+            .when_ne(local.bits[8], AB::Expr::one())
+            .assert_one(local.output);
+
+        // Check bit decomposition
+        for bit in local.bits.into_iter() {
+            builder.assert_bool(bit);
+        }
+    }
+}

--- a/alu_u32/src/lib.rs
+++ b/alu_u32/src/lib.rs
@@ -6,6 +6,7 @@ pub mod add;
 pub mod bitwise;
 pub mod div;
 pub mod lt;
+pub mod com;
 pub mod mul;
 pub mod shift;
 pub mod sub;

--- a/alu_u32/src/lib.rs
+++ b/alu_u32/src/lib.rs
@@ -4,9 +4,9 @@ extern crate alloc;
 
 pub mod add;
 pub mod bitwise;
+pub mod com;
 pub mod div;
 pub mod lt;
-pub mod com;
 pub mod mul;
 pub mod shift;
 pub mod sub;

--- a/assembler/grammar/assembly.pest
+++ b/assembler/grammar/assembly.pest
@@ -7,7 +7,7 @@ mnemonic = {
     "advread" | "advwrite" | 
     "addi" | "add" | "subi" | "sub" | "muli" | "mul" | "mulhsi"| "mulhui"| "mulhs"| "mulhu"  | "divi" | "div" | "sdiv" | "sdivi" |
     "lti" | "lt" | "shli" | "shl" | "shri" | "shr" | "srai" | "sra" |
-    "andi" | "and" | "ori" | "or" | "xori" | "xor" |
+    "andi" | "and" | "ori" | "or" | "xori" | "xor" | "nei" | "ne" | "eqi" | "eq" |
     "feadd" | "fesub" | "femul" |
     "write"
 }

--- a/assembler/src/lib.rs
+++ b/assembler/src/lib.rs
@@ -84,6 +84,8 @@ pub fn assemble(input: &str) -> Result<Vec<u8>, String> {
                     "and" | "andi" => AND32,
                     "or" | "ori" => OR32,
                     "xor" | "xori" => XOR32,
+                    "ne" | "nei" => NE32,
+                    "eq" | "eqi" => EQ32,
 
                     // Native field
                     "feadd" => ADD,
@@ -116,12 +118,14 @@ pub fn assemble(input: &str) -> Result<Vec<u8>, String> {
                         operands.extend(vec![0; 5]);
                     }
                     "add" | "sub" | "mul" | "mulhs" | "mulhu" | "div" | "lt" | "shl" | "shr"
-                    | "sra" | "beq" | "bne" | "and" | "or" | "xor" | "jal" | "jalv" => {
+                    | "sra" | "beq" | "bne" | "and" | "or" | "xor" | "ne" | "eq" | "jal"
+                    | "jalv" => {
                         // (a, b, c, 0, 0)
                         operands.extend(vec![0; 2]);
                     }
                     "addi" | "subi" | "muli" | "mulhsi" | "mulhui" | "divi" | "sdivi" | "lti"
-                    | "shli" | "shri" | "srai" | "beqi" | "bnei" | "andi" | "ori" | "xori" => {
+                    | "shli" | "shri" | "srai" | "beqi" | "bnei" | "andi" | "ori" | "xori"
+                    | "nei" | "eqi" => {
                         // (a, b, c, 0, 1)
                         operands.extend(vec![0, 1]);
                     }

--- a/basic/src/lib.rs
+++ b/basic/src/lib.rs
@@ -18,6 +18,7 @@ use valida_alu_u32::{
         And32Instruction, Bitwise32Chip, MachineWithBitwise32Chip, Or32Instruction,
         Xor32Instruction,
     },
+    com::{Com32Chip, MachineWithCom32Chip, Ne32Instruction},
     div::{Div32Chip, Div32Instruction, MachineWithDiv32Chip, SDiv32Instruction},
     lt::{Lt32Chip, Lt32Instruction, MachineWithLt32Chip},
     mul::{
@@ -279,8 +280,19 @@ impl<F: PrimeField32 + TwoAdicField> MachineWithLt32Chip<F> for BasicMachine<F> 
         &mut self.lt_u32
     }
 }
+impl<F: PrimeField32 + TwoAdicField> MachineWithCom32Chip<F> for BasicMachine<F> {
+    fn com_u32(&self) -> &Com32Chip {
+        &self.com_u32
+    }
 
-impl<F: PrimeField32 + TwoAdicField> MachineWithShift32Chip<F> for BasicMachine<F> {
+    fn com_u32_mut(&mut self) -> &mut Com32Chip {
+        &mut self.com_u32
+    }
+}
+
+impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithShift32Chip
+    for BasicMachine<F, EF>
+{
     fn shift_u32(&self) -> &Shift32Chip {
         &self.shift_u32
     }

--- a/basic/src/lib.rs
+++ b/basic/src/lib.rs
@@ -18,7 +18,7 @@ use valida_alu_u32::{
         And32Instruction, Bitwise32Chip, MachineWithBitwise32Chip, Or32Instruction,
         Xor32Instruction,
     },
-    com::{Com32Chip, MachineWithCom32Chip, Ne32Instruction},
+    com::{Com32Chip, Eq32Instruction, MachineWithCom32Chip, Ne32Instruction},
     div::{Div32Chip, Div32Instruction, MachineWithDiv32Chip, SDiv32Instruction},
     lt::{Lt32Chip, Lt32Instruction, MachineWithLt32Chip},
     mul::{
@@ -121,6 +121,12 @@ pub struct BasicMachine<F: PrimeField32 + TwoAdicField> {
     #[instruction(bitwise_u32)]
     xor32: Xor32Instruction,
 
+    #[instruction(com_u32)]
+    ne32: Ne32Instruction,
+
+    #[instruction(com_u32)]
+    eq32: Eq32Instruction,
+
     // Input/output instructions
     #[instruction]
     read: ReadAdviceInstruction,
@@ -154,6 +160,9 @@ pub struct BasicMachine<F: PrimeField32 + TwoAdicField> {
 
     #[chip]
     lt_u32: Lt32Chip,
+
+    #[chip]
+    com_u32: Com32Chip,
 
     #[chip]
     bitwise_u32: Bitwise32Chip,

--- a/basic/src/lib.rs
+++ b/basic/src/lib.rs
@@ -290,9 +290,7 @@ impl<F: PrimeField32 + TwoAdicField> MachineWithCom32Chip<F> for BasicMachine<F>
     }
 }
 
-impl<F: PrimeField64 + TwoAdicField, EF: ExtensionField<F>> MachineWithShift32Chip
-    for BasicMachine<F, EF>
-{
+impl<F: PrimeField32 + TwoAdicField> MachineWithShift32Chip<F> for BasicMachine<F> {
     fn shift_u32(&self) -> &Shift32Chip {
         &self.shift_u32
     }

--- a/opcodes/src/lib.rs
+++ b/opcodes/src/lib.rs
@@ -25,9 +25,10 @@ pub const SHR32: u32 = 106;
 pub const AND32: u32 = 107;
 pub const OR32: u32 = 108;
 pub const XOR32: u32 = 109;
-pub const MULHU32: u32 = 112;
-pub const SRA32: u32 = 113;
-pub const MULHS32: u32 = 114;
+pub const NE32: u32 = 111;
+pub const MULHU32 : u32 = 112; //TODO
+pub const SRA32 : u32 = 113; //TODO
+pub const MULHS32 : u32 =114; //TODO
 
 /// NATIVE FIELD
 pub const ADD: u32 = 200;

--- a/opcodes/src/lib.rs
+++ b/opcodes/src/lib.rs
@@ -26,9 +26,11 @@ pub const AND32: u32 = 107;
 pub const OR32: u32 = 108;
 pub const XOR32: u32 = 109;
 pub const NE32: u32 = 111;
-pub const MULHU32 : u32 = 112; //TODO
-pub const SRA32 : u32 = 113; //TODO
-pub const MULHS32 : u32 =114; //TODO
+pub const MULHU32: u32 = 112;
+pub const SRA32: u32 = 113;
+pub const MULHS32: u32 = 114;
+pub const LTE32: u32 = 115; //TODO
+pub const EQ32: u32 = 116;
 
 /// NATIVE FIELD
 pub const ADD: u32 = 200;


### PR DESCRIPTION
Before the changes, the following tests had "unrecognized opcode" errors. After the changes, the tests are behaving as expected:

2023-12-log-not 2023-12-log-not-neg 2023-12-log-and 2023-12-log-and-neg

