### PR TITLE
`READ_ADVICE` returns `-1` at the end of advice tape.

### DIFF
--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -379,10 +379,15 @@ where
         let mem_addr = fp + ops.a();
 
         // Read from the advice tape into memory
-        let advice_byte = advice.get_advice().expect("No more advice");
+        let advice_opt = advice.get_advice();
+        let advice_byte = match advice_opt {
+            Some(advice) => Word::from_u8(advice),
+            // eof
+            None => Word::from(u32::MAX),
+        };
         state
             .mem_mut()
-            .write(clk, mem_addr as u32, Word::from_u8(advice_byte), true);
+            .write(clk, mem_addr as u32, advice_byte, true);
 
         state.cpu_mut().pc += 1;
         state.cpu_mut().push_op(


### PR DESCRIPTION
Before these changes `READ_ADVICE` panics when it has reached the end of the advice tape. After these changes `READ_ADVICE` returns `-1` (similar to the `C` `stdio`). I.e., this PR changes `READ_ADVICE`'s spec to the following:

`READ_ADVICE`:
Operands: a
Description: Read the content of the advice tape and write the next byte to the low byte of the word beginning at offset `a`. If the end of the advice tape is reached, write `0xFFFFFFFF` instead.

The result of running this [test](https://github.com/lita-xyz/llvm-test-suite/pull/7/files#diff-1a2613eb8252e31ee49a48fe953e6e1c4297366667a68d3ab4e0336af230b2fa) is what you would expect of a typical `cat` program: it writes the input to `stdout`: 

```
./llvm-valida/build/bin/clang -c -target delendum ./llvm-test-suite/SingleSource/UnitTests/2024-2-cat-w-eof.c -o 2024-2-cat-w-eof.o
./llvm-valida/build/bin/ld.lld --script=./llvm-valida/valida.ld -o ./2024-2-cat-w-eof.out ./2024-2-cat-w-eof.o
./llvm-valida/build/bin/llvm-objcopy -O binary ./2024-2-cat-w-eof.out ./2024-2-cat-w-eof.out.bin
./valida-mc-fixer/result/bin/valida-mc-fixer ./2024-2-cat-w-eof.out.bin ./2024-2-cat-w-eof.out.bin.fix
./valida-mc-fixer/result/bin/valida-mc-fixer -d ./2024-2-cat-w-eof.out.bin.fix 2024-2-cat-w-eof.s
./valida/target/release/valida ./2024-2-cat-w-eof.out.bin.fix < llvm-test-suite/SingleSource/UnitTests/2024-2-cat-w-eof.c
```
returns:

```
int main() {
  int byte;
  while ((byte = __builtin_delendum_read_advice()) != -1) {
    __builtin_delendum_write(byte);
  }
  return 0;
}
```