### PR TITLE
Provide a method to allow reading advice from file

### DIFF
--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -99,7 +99,7 @@ impl Context {
         if self.stopped_ == StoppingFlag::DidStop {
             return (StoppingFlag::DidStop, 0);
         }
-        let state = self.machine_.step(&mut StdinAdviceProvider);
+        let state = self.machine_.step(&mut self.advice);
         let pc = self.machine_.cpu().pc;
         let fp = self.machine_.cpu().fp;
 
@@ -338,7 +338,7 @@ fn main() {
     machine.static_data_mut().load(data);
 
     // Run the program
-    machine.run(&code, &mut StdinAdviceProvider);
+    machine.run(&code, &mut GlobalAdviceProvider::new(&args.advice));
 
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 5>;

--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -9,7 +9,10 @@ use p3_baby_bear::BabyBear;
 
 use p3_fri::{FriConfig, TwoAdicFriPcs, TwoAdicFriPcsConfig};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{AdviceProvider, GlobalAdviceProvider, Machine, MachineProof, ProgramROM, StdinAdviceProvider, StoppingFlag};
+use valida_machine::{
+    AdviceProvider, GlobalAdviceProvider, Machine, MachineProof, ProgramROM, StdinAdviceProvider,
+    StoppingFlag,
+};
 use valida_memory::MachineWithMemoryChip;
 
 use valida_elf::{load_executable_file, Program};
@@ -65,7 +68,7 @@ struct Context {
     last_fp_: u32,
     recorded_current_fp_: u32,
     last_fp_size_: u32,
-    advice : GlobalAdviceProvider,
+    advice: GlobalAdviceProvider,
 }
 
 impl Context {
@@ -78,7 +81,7 @@ impl Context {
             last_fp_: args.stack_height,
             recorded_current_fp_: args.stack_height,
             last_fp_size_: 0,
-            advice : GlobalAdviceProvider::new(&args.advice),
+            advice: GlobalAdviceProvider::new(&args.advice),
         };
 
         let Program { code, data } = load_executable_file(

--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -9,7 +9,7 @@ use p3_baby_bear::BabyBear;
 
 use p3_fri::{FriConfig, TwoAdicFriPcs, TwoAdicFriPcsConfig};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{Machine, MachineProof, ProgramROM, StdinAdviceProvider, StoppingFlag};
+use valida_machine::{AdviceProvider, FixedAdviceProvider, Machine, MachineProof, ProgramROM, StdinAdviceProvider, StoppingFlag};
 use valida_memory::MachineWithMemoryChip;
 
 use valida_elf::{load_executable_file, Program};
@@ -61,6 +61,7 @@ struct Context {
     last_fp_: u32,
     recorded_current_fp_: u32,
     last_fp_size_: u32,
+    advice : Box<dyn AdviceProvider>,
 }
 
 impl Context {
@@ -73,6 +74,7 @@ impl Context {
             last_fp_: args.stack_height,
             recorded_current_fp_: args.stack_height,
             last_fp_size_: 0,
+            advice: Box::new(StdinAdviceProvider),
         };
 
         let Program { code, data } = load_executable_file(

--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -9,7 +9,7 @@ use p3_baby_bear::BabyBear;
 
 use p3_fri::{FriConfig, TwoAdicFriPcs, TwoAdicFriPcsConfig};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{AdviceProvider, FixedAdviceProvider, Machine, MachineProof, ProgramROM, StdinAdviceProvider, StoppingFlag};
+use valida_machine::{AdviceProvider, GlobalAdviceProvider, Machine, MachineProof, ProgramROM, StdinAdviceProvider, StoppingFlag};
 use valida_memory::MachineWithMemoryChip;
 
 use valida_elf::{load_executable_file, Program};
@@ -65,7 +65,7 @@ struct Context {
     last_fp_: u32,
     recorded_current_fp_: u32,
     last_fp_size_: u32,
-    advice : Box<dyn AdviceProvider>,
+    advice : GlobalAdviceProvider,
 }
 
 impl Context {
@@ -78,13 +78,7 @@ impl Context {
             last_fp_: args.stack_height,
             recorded_current_fp_: args.stack_height,
             last_fp_size_: 0,
-            advice: match &args.advice {
-                Some(file) => {
-                    let mut file = File::open(file).unwrap();
-                    Box::new(FixedAdviceProvider::from_file(&mut file))
-                }
-                _ => Box::new(StdinAdviceProvider),
-            },
+            advice : GlobalAdviceProvider::new(&args.advice),
         };
 
         let Program { code, data } = load_executable_file(

--- a/basic/src/bin/valida.rs
+++ b/basic/src/bin/valida.rs
@@ -51,6 +51,10 @@ struct Args {
     /// Stack height (which is also the initial frame pointer value)
     #[arg(long, default_value = "16777216")]
     stack_height: u32,
+
+    /// Advice file
+    #[arg(name = "Advice file")]
+    advice: Option<String>,
 }
 
 struct Context {
@@ -74,7 +78,13 @@ impl Context {
             last_fp_: args.stack_height,
             recorded_current_fp_: args.stack_height,
             last_fp_size_: 0,
-            advice: Box::new(StdinAdviceProvider),
+            advice: match &args.advice {
+                Some(file) => {
+                    let mut file = File::open(file).unwrap();
+                    Box::new(FixedAdviceProvider::from_file(&mut file))
+                }
+                _ => Box::new(StdinAdviceProvider),
+            },
         };
 
         let Program { code, data } = load_executable_file(

--- a/machine/src/advice.rs
+++ b/machine/src/advice.rs
@@ -1,7 +1,7 @@
 use core::slice;
+use std::fs::File;
 use std::io;
 use std::io::Read;
-use std::fs::File;
 
 pub trait AdviceProvider {
     /// Get the next byte from the advice tape, if any.
@@ -35,7 +35,7 @@ impl FixedAdviceProvider {
     pub fn new(advice: Vec<u8>) -> Self {
         Self { advice, index: 0 }
     }
-    pub fn from_file(file : &mut File) -> Self {
+    pub fn from_file(file: &mut File) -> Self {
         // read the entire file into self::advice:
         let mut advice = Vec::new();
         file.read_to_end(&mut advice).unwrap();
@@ -70,21 +70,21 @@ impl AdviceProvider for StdinAdviceProvider {
 }
 
 pub struct GlobalAdviceProvider {
-    provider : AdviceProviderType,
+    provider: AdviceProviderType,
 }
 impl GlobalAdviceProvider {
-    pub fn new(file_name : &Option<String>) -> Self {
+    pub fn new(file_name: &Option<String>) -> Self {
         match file_name {
             Some(file_name) => {
                 let mut file = File::open(file_name).unwrap();
                 let provider = AdviceProviderType::Fixed(FixedAdviceProvider::from_file(&mut file));
                 Self { provider }
-            },
+            }
             None => {
                 let provider = AdviceProviderType::Stdin(StdinAdviceProvider);
                 Self { provider }
             }
-        } 
+        }
     }
 }
 

--- a/machine/src/advice.rs
+++ b/machine/src/advice.rs
@@ -68,3 +68,28 @@ impl AdviceProvider for StdinAdviceProvider {
         }
     }
 }
+
+struct GlobalAdviceProvider {
+    provider : AdviceProviderType,
+}
+impl GlobalAdviceProvider {
+    pub fn new(file_name : Option<String>) -> Self {
+        match file_name {
+            Some(file_name) => {
+                let mut file = File::open(file_name).unwrap();
+                let provider = AdviceProviderType::Fixed(FixedAdviceProvider::from_file(&mut file));
+                Self { provider }
+            },
+            None => {
+                let provider = AdviceProviderType::Stdin(StdinAdviceProvider);
+                Self { provider }
+            }
+        } 
+    }
+}
+
+impl AdviceProvider for GlobalAdviceProvider {
+    fn get_advice(&mut self) -> Option<u8> {
+        self.provider.get_advice()
+    }
+}

--- a/machine/src/advice.rs
+++ b/machine/src/advice.rs
@@ -1,6 +1,7 @@
 use core::slice;
 use std::io;
 use std::io::Read;
+use std::fs::File;
 
 pub trait AdviceProvider {
     /// Get the next byte from the advice tape, if any.
@@ -12,12 +13,32 @@ pub struct FixedAdviceProvider {
     index: usize,
 }
 
+enum AdviceProviderType {
+    Stdin(StdinAdviceProvider),
+    Fixed(FixedAdviceProvider),
+}
+
+impl AdviceProviderType {
+    fn get_advice(&mut self) -> Option<u8> {
+        match self {
+            AdviceProviderType::Stdin(provider) => provider.get_advice(),
+            AdviceProviderType::Fixed(provider) => provider.get_advice(),
+        }
+    }
+}
+
 impl FixedAdviceProvider {
     pub fn empty() -> Self {
         Self::new(vec![])
     }
 
     pub fn new(advice: Vec<u8>) -> Self {
+        Self { advice, index: 0 }
+    }
+    pub fn from_file(file : &mut File) -> Self {
+        // read the entire file into self::advice:
+        let mut advice = Vec::new();
+        file.read_to_end(&mut advice).unwrap();
         Self { advice, index: 0 }
     }
 }

--- a/machine/src/advice.rs
+++ b/machine/src/advice.rs
@@ -69,11 +69,11 @@ impl AdviceProvider for StdinAdviceProvider {
     }
 }
 
-struct GlobalAdviceProvider {
+pub struct GlobalAdviceProvider {
     provider : AdviceProviderType,
 }
 impl GlobalAdviceProvider {
-    pub fn new(file_name : Option<String>) -> Self {
+    pub fn new(file_name : &Option<String>) -> Self {
         match file_name {
             Some(file_name) => {
                 let mut file = File::open(file_name).unwrap();


### PR DESCRIPTION
Adds an extra, optional command line option which allows to initialize `FixedAdviceProvider` to the binary content of the file. This will allow easier test framework building.