### PR TITLE
Add word alignment checks for `LOAD32` and `STORE32`

### DIFF
--- a/machine/src/core.rs
+++ b/machine/src/core.rs
@@ -17,6 +17,10 @@ pub fn index_of_byte(addr: u32) -> usize {
 pub fn addr_of_word(addr: u32) -> u32 {
     (addr & !3) as u32
 }
+
+pub fn is_mul_4(addr: u32) -> bool {
+    addr.rem_euclid(4) == 0
+}
 //----------------------------------
 
 impl Word<u8> {


### PR DESCRIPTION
If any of the read/write addresses are not multiple of 4, the VM panics with an error message describing which opcode and read/write address is the problem.

I've confirmed that these checks work on runtime. I.e., I made a false assertion to an address value and confirmed that the VM does panic.

I've confirmed that cargo test and C unit tests all pass locally.