### PR TITLE
STARK constraints for signed inequality instructions

### DIFF
--- a/alu_u32/src/lt/columns.rs
+++ b/alu_u32/src/lt/columns.rs
@@ -13,7 +13,7 @@ pub struct Lt32Cols<T> {
     pub byte_flag: [T; 4],
 
     /// Bit decomposition of 256 + input_1 - input_2
-    pub bits: [T; 10],
+    pub bits: [T; 9],
 
     pub output: T,
 
@@ -21,9 +21,18 @@ pub struct Lt32Cols<T> {
 
     pub is_lt: T,
     pub is_lte: T,
+    pub is_slt: T,
+    pub is_sle: T,
 
     // inverse of input_1[i] - input_2[i] where i is the first byte that differs
     pub diff_inv: T,
+
+    // bit decomposition of top bytes for input_1 and input_2
+    pub top_bits_1: [T; 8],
+    pub top_bits_2: [T; 8],
+
+    // boolean flag for whether the sign of the two inputs is different
+    pub different_signs: T,
 }
 
 pub const NUM_LT_COLS: usize = size_of::<Lt32Cols<u8>>();

--- a/alu_u32/src/lt/mod.rs
+++ b/alu_u32/src/lt/mod.rs
@@ -96,28 +96,32 @@ impl Lt32Chip {
         match op {
             Operation::Lt32(a, b, c) => {
                 cols.is_lt = F::one();
-                self.set_cols(cols, a, b, c);
-                cols.different_signs = F::zero();
+                self.set_cols(cols, false, a, b, c);
             }
             Operation::Lte32(a, b, c) => {
                 cols.is_lte = F::one();
-                self.set_cols(cols, a, b, c);
-                cols.different_signs = F::zero();
+                self.set_cols(cols, false, a, b, c);
             }
             Operation::Slt32(a, b, c) => {
                 cols.is_slt = F::one();
-                self.set_cols(cols, a, b, c);
+                self.set_cols(cols, true, a, b, c);
             }
             Operation::Sle32(a, b, c) => {
                 cols.is_sle = F::one();
-                self.set_cols(cols, a, b, c);
+                self.set_cols(cols, true, a, b, c);
             }
         }
         row
     }
 
-    fn set_cols<F>(&self, cols: &mut Lt32Cols<F>, a: &Word<u8>, b: &Word<u8>, c: &Word<u8>)
-    where
+    fn set_cols<F>(
+        &self,
+        cols: &mut Lt32Cols<F>,
+        is_signed: bool,
+        a: &Word<u8>,
+        b: &Word<u8>,
+        c: &Word<u8>,
+    ) where
         F: PrimeField,
     {
         // Set the input columns
@@ -148,8 +152,12 @@ impl Lt32Chip {
             cols.top_bits_2[i] = F::from_canonical_u8(c[0] >> i & 1);
         }
         // check if sign bits agree and set different_signs accordingly
-        cols.different_signs = if cols.top_bits_1[7] != cols.top_bits_2[7] {
-            F::one()
+        cols.different_signs = if is_signed {
+            if cols.top_bits_1[7] != cols.top_bits_2[7] {
+                F::one()
+            } else {
+                F::zero()
+            }
         } else {
             F::zero()
         };

--- a/alu_u32/src/lt/mod.rs
+++ b/alu_u32/src/lt/mod.rs
@@ -97,10 +97,12 @@ impl Lt32Chip {
             Operation::Lt32(a, b, c) => {
                 cols.is_lt = F::one();
                 self.set_cols(cols, a, b, c);
+                cols.different_signs = F::zero();
             }
             Operation::Lte32(a, b, c) => {
                 cols.is_lte = F::one();
                 self.set_cols(cols, a, b, c);
+                cols.different_signs = F::zero();
             }
             Operation::Slt32(a, b, c) => {
                 cols.is_slt = F::one();

--- a/alu_u32/src/lt/stark.rs
+++ b/alu_u32/src/lt/stark.rs
@@ -92,9 +92,18 @@ where
         builder.assert_eq(top_comp_1, local.input_1[0]);
         builder.assert_eq(top_comp_2, local.input_2[0]);
 
+        let is_signed = local.is_slt + local.is_sle;
+        let is_unsigned = AB::Expr::one() - is_signed.clone();
+        let same_sign = AB::Expr::one() - local.different_signs;
+        let are_equal = AB::Expr::one() - flag_sum.clone();
+
+        builder
+            .when(is_unsigned.clone())
+            .assert_zero(local.different_signs);
+
         // Check that `different_signs` is set correctly by comparing sign bits.
         builder
-            .when(local.byte_flag[0])
+            .when(is_signed.clone())
             .when_ne(local.top_bits_1[7], local.top_bits_2[7])
             .assert_eq(local.different_signs, AB::Expr::one());
         builder
@@ -110,11 +119,6 @@ where
         builder.assert_bool(local.is_slt);
         builder.assert_bool(local.is_sle);
         builder.assert_bool(local.is_lt + local.is_lte + local.is_slt + local.is_sle);
-
-        let is_signed = local.is_slt + local.is_sle;
-        let is_unsigned = AB::Expr::one() - is_signed;
-        let same_sign = AB::Expr::one() - local.different_signs;
-        let are_equal = AB::Expr::one() - flag_sum.clone();
 
         // Output constraints
         // Case 0: input_1 > input_2 as unsigned ints; equivalently, local.bits[8] == 1

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -290,6 +290,7 @@ fn signed_inequality_program<Val: PrimeField32 + TwoAdicField>() -> Vec<Instruct
     // slt32 24(fp), -1, -12(fp), 1, 0
     // slt32 28(fp), -8(fp), -12(fp), 0, 0
     // slt32 32(fp), -8(fp), -4(fp), 0, 0
+
     program.extend([
         InstructionWord {
             opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
@@ -370,7 +371,7 @@ fn signed_inequality_program<Val: PrimeField32 + TwoAdicField>() -> Vec<Instruct
         // stop 0, 0, 0, 0, 0
         InstructionWord {
             opcode: <StopInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
-            operands: Operands::default(),
+            operands: Operands([0, 0, 0, 0, 0]),
         },
     ]);
 

--- a/basic/tests/test_prover.rs
+++ b/basic/tests/test_prover.rs
@@ -3,7 +3,7 @@ extern crate core;
 use p3_baby_bear::BabyBear;
 use p3_fri::{TwoAdicFriPcs, TwoAdicFriPcsConfig};
 use valida_alu_u32::add::{Add32Instruction, MachineWithAdd32Chip};
-use valida_alu_u32::lt::{Lt32Instruction, Lte32Instruction};
+use valida_alu_u32::lt::{Lt32Instruction, Lte32Instruction, Sle32Instruction, Slt32Instruction};
 use valida_basic::BasicMachine;
 use valida_cpu::{
     BeqInstruction, BneInstruction, Imm32Instruction, JalInstruction, JalvInstruction,
@@ -261,6 +261,122 @@ fn left_imm_ops_program<Val: PrimeField32 + TwoAdicField>() -> Vec<InstructionWo
     program
 }
 
+fn signed_inequality_program<Val: PrimeField32 + TwoAdicField>() -> Vec<InstructionWord<i32>> {
+    let mut program = vec![];
+
+    // imm32 -4(fp), 0, 0, 0, 1
+    // imm32 -8(fp), 255, 255, 255, 255
+    // imm32 -12(fp), 255, 255, 255, 254
+    program.extend([
+        InstructionWord {
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([-4, 0, 0, 0, 1]),
+        },
+        InstructionWord {
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([-8, 255, 255, 255, 255]),
+        },
+        InstructionWord {
+            opcode: <Imm32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([-12, 255, 255, 255, 254]),
+        },
+    ]);
+
+    // slt32 4(fp), -12(fp), -8(fp), 0, 0
+    // slt32 8(fp), -12(fp), -4(fp), 0, 0
+    // slt32 12(fp), -4(fp), -1, 0, 1
+    // slt32 16(fp), -1, -8(fp), 1, 0
+    // sle32 20(fp), -1, -8(fp), 1, 0
+    // slt32 24(fp), -1, -12(fp), 1, 0
+    // slt32 28(fp), -8(fp), -12(fp), 0, 0
+    // slt32 32(fp), -8(fp), -4(fp), 0, 0
+    program.extend([
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([4, -12, -8, 0, 0]),
+        },
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([8, -12, -4, 0, 0]),
+        },
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([12, -4, -1, 0, 1]),
+        },
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([16, -1, -8, 1, 0]),
+        },
+        InstructionWord {
+            opcode: <Sle32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([20, -1, -8, 1, 0]),
+        },
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([24, -1, -12, 1, 0]),
+        },
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([28, -8, -12, 0, 0]),
+        },
+        InstructionWord {
+            opcode: <Slt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([32, -8, -4, 0, 0]),
+        },
+    ]);
+
+    // lt32 36(fp), -12(fp), -8(fp), 0, 0
+    // lt32 40(fp), -12(fp), -4(fp), 0, 0
+    // lt32 44(fp), -4(fp), -1, 0, 1
+    // lt32 48(fp), -1, -8(fp), 1, 0
+    // lte32 52(fp), -1, -8(fp), 1, 0
+    // lt32 56(fp), -1, -12(fp), 1, 0
+    // lt32 60(fp), -8(fp), -12(fp), 0, 0
+    // lt32 64(fp), -8(fp), -4(fp), 0, 0
+    // stop
+    program.extend([
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([36, -12, -8, 0, 0]),
+        },
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([40, -12, -4, 0, 0]),
+        },
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([44, -4, -1, 0, 1]),
+        },
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([48, -1, -8, 1, 0]),
+        },
+        InstructionWord {
+            opcode: <Lte32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([52, -1, -8, 1, 0]),
+        },
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([56, -1, -12, 1, 0]),
+        },
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([60, -8, -12, 0, 0]),
+        },
+        InstructionWord {
+            opcode: <Lt32Instruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands([64, -8, -4, 0, 0]),
+        },
+        // stop 0, 0, 0, 0, 0
+        InstructionWord {
+            opcode: <StopInstruction as Instruction<BasicMachine<Val>, Val>>::OPCODE,
+            operands: Operands::default(),
+        },
+    ]);
+
+    program
+}
+
 fn prove_program(program: Vec<InstructionWord<i32>>) -> BasicMachine<BabyBear> {
     let mut machine = BasicMachine::<Val>::default();
     let rom = ProgramROM::new(program);
@@ -351,7 +467,6 @@ fn prove_left_imm_ops() {
     let program = left_imm_ops_program::<BabyBear>();
 
     let machine = prove_program(program);
-
     assert_eq!(
         *machine.mem().cells.get(&(0x1000 + 4)).unwrap(),
         Word([0, 0, 0, 0]) // 3 < 3 (false)
@@ -391,5 +506,80 @@ fn prove_left_imm_ops() {
     assert_eq!(
         *machine.mem().cells.get(&(0x1000 + 40)).unwrap(),
         Word([0, 0, 0, 1]) // 3 <= 256 (false)
+    );
+}
+
+#[test]
+fn prove_signed_inequality() {
+    let program = signed_inequality_program::<BabyBear>();
+
+    let machine = prove_program(program);
+
+    // signed inequalities
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 4)).unwrap(),
+        Word([0, 0, 0, 1]) // -2 < -1 (true)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 8)).unwrap(),
+        Word([0, 0, 0, 1]) // -2 < 1 (true)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 12)).unwrap(),
+        Word([0, 0, 0, 0]) // 1 < -1 (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 16)).unwrap(),
+        Word([0, 0, 0, 0]) // -1 < -1 (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 20)).unwrap(),
+        Word([0, 0, 0, 1]) // -1 <= -1 (true)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 24)).unwrap(),
+        Word([0, 0, 0, 0]) // -1 < -2 (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 28)).unwrap(),
+        Word([0, 0, 0, 0]) // -1 < -2 (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 32)).unwrap(),
+        Word([0, 0, 0, 1]) // -1 < 1 (true)
+    );
+
+    // unsigned inequalities
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 36)).unwrap(),
+        Word([0, 0, 0, 1]) // 0xFFFFFFFE < 0xFFFFFFFF (true)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 40)).unwrap(),
+        Word([0, 0, 0, 0]) // 0xFFFFFFFE < 1 (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 44)).unwrap(),
+        Word([0, 0, 0, 1]) // 1 < 0xFFFFFFFF (true)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 48)).unwrap(),
+        Word([0, 0, 0, 0]) // 0xFFFFFFFF < 0xFFFFFFFFFF (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 52)).unwrap(),
+        Word([0, 0, 0, 1]) // 0xFFFFFFFF <= 0xFFFFFFFF (true)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 56)).unwrap(),
+        Word([0, 0, 0, 0]) // 0xFFFFFFFF < 0xFFFFFFFE (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 60)).unwrap(),
+        Word([0, 0, 0, 0]) // 0xFFFFFFFF < 0xFFFFFFFE (false)
+    );
+    assert_eq!(
+        *machine.mem().cells.get(&(0x1000 + 64)).unwrap(),
+        Word([0, 0, 0, 0]) // 0xFFFFFFFF < 1 (false)
     );
 }


### PR DESCRIPTION
This addresses Issue #160 by implementing constraints for the signed inequality instructions, including a suite of tests included in `basic/tests/test_prover.rs`. 