### PR TITLE
Prover fixes for Bitwise32Chip

### DIFF
--- a/alu_u32/src/bitwise/columns.rs
+++ b/alu_u32/src/bitwise/columns.rs
@@ -4,7 +4,7 @@ use valida_derive::AlignedBorrow;
 use valida_machine::Word;
 use valida_util::indices_arr;
 
-#[derive(AlignedBorrow, Default)]
+#[derive(AlignedBorrow, Default, Debug)]
 pub struct Bitwise32Cols<T> {
     pub input_1: Word<T>,
     pub input_2: Word<T>,

--- a/alu_u32/src/bitwise/mod.rs
+++ b/alu_u32/src/bitwise/mod.rs
@@ -19,7 +19,7 @@ use valida_util::pad_to_power_of_two;
 pub mod columns;
 pub mod stark;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Operation {
     And32(Word<u8>, Word<u8>, Word<u8>), // (dst, src1, src2)
     Or32(Word<u8>, Word<u8>, Word<u8>),  // ''
@@ -124,6 +124,8 @@ impl Bitwise32Chip {
                 bits_2[i][j] = F::from_canonical_u8(c[i] >> j & 1);
             }
         }
+        cols.bits_1 = bits_1;
+        cols.bits_2 = bits_2;
     }
 }
 

--- a/alu_u32/src/bitwise/mod.rs
+++ b/alu_u32/src/bitwise/mod.rs
@@ -248,7 +248,7 @@ where
         state
             .bitwise_u32_mut()
             .operations
-            .push(Operation::And32(a, b, c));
+            .push(Operation::Or32(a, b, c));
         state.cpu_mut().push_bus_op(imm, opcode, ops);
     }
 }


### PR DESCRIPTION
This addresses Issue #130. 

Currently, the prover for the `Bitwise32Chip` computes the bit decomposition of the inputs but does not record the result in the trace. Additionally, `Or32` instructions were mistakenly being processed as `And32` instructions. 

The former error is causing the proof for _any_ bitwise instruction (with nonzero inputs) not to verify, and the latter causes the proof for any `Or32` instruction whose output is different than `And32` for the same inputs to fail to verify. This can be seen currently in several tests in the test suite resulting in `OodEvaluationMismatch` errors on Chip 10: with this PR, those errors all disappear. 