### PR TITLE
Public Instance Data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,47 +34,48 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -82,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
@@ -124,9 +125,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -205,7 +206,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -216,9 +217,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "core-foundation-sys"
@@ -286,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -323,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -381,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elf"
@@ -399,9 +400,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -430,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -518,6 +519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,15 +559,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -607,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -650,7 +657,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -659,7 +666,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "rand",
@@ -669,7 +676,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -680,7 +687,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -691,7 +698,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -702,7 +709,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "itertools 0.12.1",
  "p3-util",
@@ -713,7 +720,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -731,7 +738,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-util",
@@ -742,7 +749,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -753,7 +760,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-symmetric",
  "tiny-keccak",
@@ -762,7 +769,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -773,7 +780,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "rayon",
 ]
@@ -781,7 +788,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-baby-bear",
  "p3-dft",
@@ -797,7 +804,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
@@ -813,7 +820,7 @@ dependencies = [
 [[package]]
 name = "p3-mersenne-31"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "criterion",
  "itertools 0.12.1",
@@ -829,7 +836,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -840,7 +847,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -849,7 +856,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
@@ -867,16 +874,16 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/valida-xyz/Plonky3.git?branch=valida-main#bdd338d61b3c1f24f17abd3b2848f1c910c49428"
+source = "git+https://github.com/valida-xyz/Plonky3.git?branch=dorebell-public#32eeeae9efaa5583aa6adfa89aca8679686709ee"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -926,7 +933,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -948,9 +955,9 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -961,15 +968,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
@@ -992,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -1165,15 +1172,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1192,29 +1199,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1299,7 +1306,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1315,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1326,22 +1333,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1365,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -1399,7 +1406,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1526,48 +1533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "valida-basic-macro"
-version = "0.1.0"
-dependencies = [
- "byteorder",
- "ciborium",
- "clap",
- "p3-air",
- "p3-baby-bear",
- "p3-challenger",
- "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-fri",
- "p3-goldilocks",
- "p3-keccak",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-mds",
- "p3-merkle-tree",
- "p3-poseidon",
- "p3-symmetric",
- "p3-uni-stark",
- "p3-util",
- "rand",
- "rand_pcg",
- "rand_seeder",
- "tracing",
- "valida-alu-u32",
- "valida-assembler",
- "valida-bus",
- "valida-cpu",
- "valida-derive",
- "valida-machine",
- "valida-memory",
- "valida-opcodes",
- "valida-output",
- "valida-program",
- "valida-range",
- "valida-static-data",
-]
-
-[[package]]
 name = "valida-bus"
 version = "0.1.0"
 dependencies = [
@@ -1626,6 +1591,7 @@ dependencies = [
  "p3-commit",
  "p3-dft",
  "p3-field",
+ "p3-interpolation",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-uni-stark",
@@ -1821,7 +1787,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -1843,7 +1809,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "assembler",
     "alu_u32",
     "basic",
-    "basic_macro",
+    #"basic_macro",
     "bus",
     "cpu",
     "derive",
@@ -22,20 +22,21 @@ members = [
 ]
 
 [workspace.dependencies]
-p3-air = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-baby-bear = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-commit = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-challenger = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-dft = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-field = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-fri = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-goldilocks = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-keccak = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-matrix = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-maybe-rayon = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-mds = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-merkle-tree = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-poseidon = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-symmetric = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-uni-stark = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
-p3-util = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "valida-main" }
+p3-air = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-baby-bear = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-commit = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-challenger = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-dft = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-field = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-fri = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-goldilocks = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-interpolation = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-keccak = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-matrix = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-maybe-rayon = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-mds = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-merkle-tree = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-poseidon = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-symmetric = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-uni-stark = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }
+p3-util = { git = "https://github.com/valida-xyz/Plonky3.git", branch = "dorebell-public" }

--- a/alu_u32/src/add/mod.rs
+++ b/alu_u32/src/add/mod.rs
@@ -6,7 +6,9 @@ use columns::{Add32Cols, ADD_COL_MAP, NUM_ADD_COLS};
 use core::mem::transmute;
 use valida_bus::{MachineWithGeneralBus, MachineWithRangeBus8};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, ValidaPublicValues, Word,
+};
 use valida_opcodes::ADD32;
 use valida_range::MachineWithRangeChip;
 
@@ -35,6 +37,8 @@ where
     M: MachineWithGeneralBus<SC::Val> + MachineWithRangeBus8<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/alu_u32/src/bitwise/mod.rs
+++ b/alu_u32/src/bitwise/mod.rs
@@ -6,7 +6,9 @@ use columns::{Bitwise32Cols, COL_MAP, NUM_BITWISE_COLS};
 use core::mem::transmute;
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, ValidaPublicValues, Word,
+};
 use valida_opcodes::{AND32, OR32, XOR32};
 
 use p3_air::VirtualPairCol;
@@ -36,6 +38,8 @@ where
     M: MachineWithGeneralBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/alu_u32/src/com/mod.rs
+++ b/alu_u32/src/com/mod.rs
@@ -7,10 +7,11 @@ use core::iter;
 use core::mem::transmute;
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::StarkConfig;
 use valida_machine::{
-    instructions, Chip, Instruction, Interaction, Operands, Word, MEMORY_CELL_BYTES,
+    instructions, Chip, Instruction, Interaction, Operands, ValidaPublicValues, Word,
+    MEMORY_CELL_BYTES,
 };
+use valida_machine::{PublicRow, StarkConfig};
 use valida_opcodes::{EQ32, NE32};
 
 use p3_air::VirtualPairCol;
@@ -38,6 +39,8 @@ where
     M: MachineWithGeneralBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/alu_u32/src/div/mod.rs
+++ b/alu_u32/src/div/mod.rs
@@ -8,6 +8,7 @@ use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
 use valida_machine::SDiv;
 use valida_machine::StarkConfig;
+use valida_machine::ValidaPublicValues;
 use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
 use valida_opcodes::{DIV32, SDIV32};
 use valida_range::MachineWithRangeChip;
@@ -37,6 +38,8 @@ where
     M: MachineWithGeneralBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/alu_u32/src/lt/mod.rs
+++ b/alu_u32/src/lt/mod.rs
@@ -8,7 +8,8 @@ use core::mem::transmute;
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
 use valida_machine::{
-    instructions, Chip, Instruction, Interaction, Operands, Word, MEMORY_CELL_BYTES,
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, ValidaPublicValues, Word,
+    MEMORY_CELL_BYTES,
 };
 use valida_opcodes::{LT32, LTE32, SLE32, SLT32};
 
@@ -40,6 +41,8 @@ where
     M: MachineWithGeneralBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/alu_u32/src/mul/mod.rs
+++ b/alu_u32/src/mul/mod.rs
@@ -5,7 +5,10 @@ use alloc::vec::Vec;
 use columns::{Mul32Cols, MUL_COL_MAP, NUM_MUL_COLS};
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Mulhs, Mulhu, Operands, Word};
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Mulhs, Mulhu, Operands, PublicRow,
+    ValidaPublicValues, Word,
+};
 use valida_opcodes::{MUL32, MULHS32, MULHU32};
 use valida_range::MachineWithRangeChip;
 
@@ -35,6 +38,8 @@ where
     M: MachineWithGeneralBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         const MIN_LENGTH: usize = 1 << 10; // for the range check counter
 

--- a/alu_u32/src/shift/mod.rs
+++ b/alu_u32/src/shift/mod.rs
@@ -8,7 +8,10 @@ use columns::{Shift32Cols, COL_MAP, NUM_SHIFT_COLS};
 use core::mem::transmute;
 use valida_bus::{MachineWithGeneralBus, MachineWithRangeBus8};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Sra, Word};
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, Sra, ValidaPublicValues,
+    Word,
+};
 use valida_opcodes::{DIV32, MUL32, SDIV32, SHL32, SHR32, SRA32};
 
 use p3_air::VirtualPairCol;
@@ -38,6 +41,8 @@ where
     M: MachineWithGeneralBus<SC::Val> + MachineWithRangeBus8<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/alu_u32/src/sub/mod.rs
+++ b/alu_u32/src/sub/mod.rs
@@ -6,7 +6,9 @@ use columns::{Sub32Cols, NUM_SUB_COLS, SUB_COL_MAP};
 use core::mem::transmute;
 use valida_bus::{MachineWithGeneralBus, MachineWithRangeBus8};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, ValidaPublicValues, Word,
+};
 use valida_opcodes::SUB32;
 use valida_range::MachineWithRangeChip;
 
@@ -35,6 +37,8 @@ where
     M: MachineWithGeneralBus<SC::Val> + MachineWithRangeBus8<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/basic_macro/src/lib.rs
+++ b/basic_macro/src/lib.rs
@@ -40,7 +40,7 @@ use valida_cpu::{CpuChip, MachineWithCpuChip};
 use valida_derive::Machine;
 use valida_machine::{
     AdviceProvider, BusArgument, Chip, ChipProof, Instruction, Machine, MachineProof, ProgramROM,
-    StoppingFlag, ValidaAirBuilder, ColumnVector, ColumnIndex,
+    StoppingFlag, ValidaAirBuilder,
 };
 use valida_memory::{MachineWithMemoryChip, MemoryChip};
 use valida_output::{MachineWithOutputChip, OutputChip, WriteInstruction};

--- a/basic_macro/src/lib.rs
+++ b/basic_macro/src/lib.rs
@@ -40,7 +40,7 @@ use valida_cpu::{CpuChip, MachineWithCpuChip};
 use valida_derive::Machine;
 use valida_machine::{
     AdviceProvider, BusArgument, Chip, ChipProof, Instruction, Machine, MachineProof, ProgramROM,
-    StoppingFlag, ValidaAirBuilder,
+    StoppingFlag, ValidaAirBuilder, ColumnVector, ColumnIndex,
 };
 use valida_memory::{MachineWithMemoryChip, MemoryChip};
 use valida_output::{MachineWithOutputChip, OutputChip, WriteInstruction};

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -11,9 +11,10 @@ use core::marker::Sync;
 use core::mem::transmute;
 use valida_bus::{MachineWithGeneralBus, MachineWithMemBus, MachineWithProgramBus};
 use valida_machine::is_mul_4;
+use valida_machine::ValidaPublicValues;
 use valida_machine::{
     addr_of_word, index_of_byte, instructions, AdviceProvider, Chip, Instruction, InstructionWord,
-    Interaction, Operands, Word,
+    Interaction, Operands, PublicRow, Word,
 };
 use valida_memory::{MachineWithMemoryChip, Operation as MemoryOperation};
 use valida_opcodes::{
@@ -76,6 +77,8 @@ where
         + Sync,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, machine: &M) -> RowMajorMatrix<SC::Val> {
         let mut rows = self
             .operations

--- a/machine/Cargo.toml
+++ b/machine/Cargo.toml
@@ -11,7 +11,10 @@ std = []
 [dependencies]
 byteorder = "1.4.3"
 itertools = "0.12.0"
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
 tracing = "0.1.37"
 
 valida-opcodes = { path = "../opcodes" }
@@ -22,6 +25,7 @@ p3-commit = { workspace = true }
 p3-challenger = { workspace = true }
 p3-dft = { workspace = true }
 p3-field = { workspace = true }
+p3-interpolation = { workspace = true }
 p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 p3-uni-stark = { workspace = true }

--- a/machine/src/chip.rs
+++ b/machine/src/chip.rs
@@ -1,5 +1,5 @@
 use crate::folding_builder::VerifierConstraintFolder;
-use crate::Machine;
+use crate::{Machine, ColumnVector, ColumnIndex};
 use crate::__internal::{DebugConstraintBuilder, ProverConstraintFolder};
 use alloc::vec;
 use alloc::vec::Vec;
@@ -20,6 +20,10 @@ pub trait Chip<M: Machine<SC::Val>, SC: StarkConfig>:
 {
     /// Generate the main trace for the chip given the provided machine.
     fn generate_trace(&self, machine: &M) -> RowMajorMatrix<SC::Val>;
+
+    fn generate_public_inputs(&self) -> Vec<(ColumnIndex, ColumnVector<SC::Val>)> {
+        vec![]
+    }
 
     fn local_sends(&self) -> Vec<Interaction<SC::Val>> {
         vec![]

--- a/machine/src/chip.rs
+++ b/machine/src/chip.rs
@@ -1,28 +1,33 @@
-use crate::folding_builder::VerifierConstraintFolder;
-use crate::{Machine, ColumnVector, ColumnIndex};
 use crate::__internal::{DebugConstraintBuilder, ProverConstraintFolder};
+use crate::folding_builder::VerifierConstraintFolder;
+use crate::public::PublicValues;
+use crate::Machine;
 use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::config::StarkConfig;
 use crate::symbolic::symbolic_builder::SymbolicAirBuilder;
 use p3_air::ExtensionBuilder;
-use p3_air::{Air, PairBuilder, PermutationAirBuilder, VirtualPairCol};
+use p3_air::{Air, AirBuilderWithPublicValues, PairBuilder, PermutationAirBuilder, VirtualPairCol};
 use p3_field::{AbstractField, ExtensionField, Field, Powers};
 use p3_matrix::{dense::RowMajorMatrix, Matrix, MatrixRowSlices};
 use valida_util::batch_multiplicative_inverse_allowing_zero;
 
-pub trait Chip<M: Machine<SC::Val>, SC: StarkConfig>:
+pub trait Chip<M, SC>:
     for<'a> Air<ProverConstraintFolder<'a, M, SC>>
     + for<'a> Air<VerifierConstraintFolder<'a, M, SC>>
     + for<'a> Air<SymbolicAirBuilder<'a, M, SC>>
     + for<'a> Air<DebugConstraintBuilder<'a, M, SC>>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
 {
+    type Public: PublicValues<SC::Val, SC::Challenge>;
     /// Generate the main trace for the chip given the provided machine.
     fn generate_trace(&self, machine: &M) -> RowMajorMatrix<SC::Val>;
 
-    fn generate_public_inputs(&self) -> Vec<(ColumnIndex, ColumnVector<SC::Val>)> {
-        vec![]
+    fn generate_public_values(&self) -> Option<Self::Public> {
+        None
     }
 
     fn local_sends(&self) -> Vec<Interaction<SC::Val>> {
@@ -71,7 +76,9 @@ pub trait Chip<M: Machine<SC::Val>, SC: StarkConfig>:
     }
 }
 
-pub trait ValidaAirBuilder: PairBuilder + PermutationAirBuilder {
+pub trait ValidaAirBuilder:
+    PairBuilder + PermutationAirBuilder + AirBuilderWithPublicValues
+{
     type Machine;
 
     fn machine(&self) -> &Self::Machine;
@@ -122,15 +129,16 @@ impl<F: Field> Interaction<F> {
 
 /// Generate the permutation trace for a chip with the provided machine.
 /// This is called only after `generate_trace` has been called on all chips.
-pub fn generate_permutation_trace<M, SC>(
+pub fn generate_permutation_trace<M, SC, P>(
     machine: &M,
-    chip: &dyn Chip<M, SC>,
+    chip: &dyn Chip<M, SC, Public = P>,
     main: &RowMajorMatrix<SC::Val>,
     random_elements: Vec<SC::Challenge>,
 ) -> RowMajorMatrix<SC::Challenge>
 where
     M: Machine<SC::Val>,
     SC: StarkConfig,
+    P: PublicValues<SC::Val, SC::Challenge>,
 {
     let all_interactions = chip.all_interactions(machine);
     let (alphas_local, alphas_global) = generate_rlc_elements(machine, chip, &random_elements);
@@ -292,14 +300,15 @@ pub fn eval_permutation_constraints<M, C, SC, AB>(
     );
 }
 
-fn generate_rlc_elements<M, SC>(
+fn generate_rlc_elements<M, SC, P>(
     machine: &M,
-    chip: &dyn Chip<M, SC>,
+    chip: &dyn Chip<M, SC, Public = P>,
     random_elements: &[SC::Challenge],
 ) -> (Vec<SC::Challenge>, Vec<SC::Challenge>)
 where
     M: Machine<SC::Val>,
     SC: StarkConfig,
+    P: PublicValues<SC::Val, SC::Challenge>,
 {
     let alphas_local = random_elements[0]
         .powers()

--- a/machine/src/debug_builder.rs
+++ b/machine/src/debug_builder.rs
@@ -1,5 +1,8 @@
 use crate::{Machine, ValidaAirBuilder};
-use p3_air::{AirBuilder, ExtensionBuilder, PairBuilder, PermutationAirBuilder, TwoRowMatrixView};
+use p3_air::{
+    AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PairBuilder, PermutationAirBuilder,
+    TwoRowMatrixView,
+};
 use p3_field::AbstractField;
 use valida_machine::StarkConfig;
 /// An `AirBuilder` which asserts that each constraint is zero, allowing any failed constraints to
@@ -13,6 +16,7 @@ pub struct DebugConstraintBuilder<'a, M: Machine<SC::Val>, SC: StarkConfig> {
     pub(crate) is_first_row: SC::Val,
     pub(crate) is_last_row: SC::Val,
     pub(crate) is_transition: SC::Val,
+    pub(crate) public_values: TwoRowMatrixView<'a, SC::Val>,
 }
 
 impl<'a, M, SC> AirBuilder for DebugConstraintBuilder<'a, M, SC>
@@ -110,5 +114,15 @@ where
 
     fn machine(&self) -> &Self::Machine {
         self.machine
+    }
+}
+
+impl<'a, M: Machine<SC::Val>, SC> AirBuilderWithPublicValues for DebugConstraintBuilder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    fn public_values(&self) -> Self::M {
+        self.public_values
     }
 }

--- a/machine/src/folding_builder.rs
+++ b/machine/src/folding_builder.rs
@@ -1,10 +1,14 @@
 use crate::{Machine, ValidaAirBuilder};
-use p3_air::{AirBuilder, ExtensionBuilder, PairBuilder, PermutationAirBuilder, TwoRowMatrixView};
+use p3_air::{
+    AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PairBuilder, PermutationAirBuilder,
+    TwoRowMatrixView,
+};
 use p3_field::AbstractField;
 use valida_machine::StarkConfig;
 
 pub struct ProverConstraintFolder<'a, M: Machine<SC::Val>, SC: StarkConfig> {
     pub(crate) machine: &'a M,
+    pub(crate) public_values: TwoRowMatrixView<'a, SC::PackedVal>,
     pub(crate) preprocessed: TwoRowMatrixView<'a, SC::PackedVal>,
     pub(crate) main: TwoRowMatrixView<'a, SC::PackedVal>,
     pub(crate) perm: TwoRowMatrixView<'a, SC::PackedChallenge>,
@@ -20,6 +24,7 @@ pub struct VerifierConstraintFolder<'a, M, SC: StarkConfig> {
     pub(crate) machine: &'a M,
     pub(crate) preprocessed: TwoRowMatrixView<'a, SC::Challenge>,
     pub(crate) main: TwoRowMatrixView<'a, SC::Challenge>,
+    pub(crate) public_values: TwoRowMatrixView<'a, SC::Challenge>,
     pub(crate) perm: TwoRowMatrixView<'a, SC::Challenge>,
     pub(crate) perm_challenges: &'a [SC::Challenge],
     pub(crate) is_first_row: SC::Challenge,
@@ -124,6 +129,16 @@ where
     }
 }
 
+impl<'a, M, SC> AirBuilderWithPublicValues for ProverConstraintFolder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    fn public_values(&self) -> Self::M {
+        self.public_values
+    }
+}
+
 impl<'a, M, SC> AirBuilder for VerifierConstraintFolder<'a, M, SC>
 where
     M: Machine<SC::Val>,
@@ -213,5 +228,15 @@ where
 
     fn machine(&self) -> &Self::Machine {
         self.machine
+    }
+}
+
+impl<'a, M, SC> AirBuilderWithPublicValues for VerifierConstraintFolder<'a, M, SC>
+where
+    M: Machine<SC::Val>,
+    SC: StarkConfig,
+{
+    fn public_values(&self) -> Self::M {
+        self.public_values
     }
 }

--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -15,6 +15,7 @@ mod folding_builder;
 mod machine;
 mod program;
 mod proof;
+mod public;
 mod quotient;
 mod symbolic;
 mod verify;
@@ -27,6 +28,7 @@ pub use error::*;
 pub use machine::*;
 pub use program::*;
 pub use proof::*;
+pub use public::*;
 pub use verify::*;
 
 pub const OPERAND_ELEMENTS: usize = 5;

--- a/machine/src/public.rs
+++ b/machine/src/public.rs
@@ -1,0 +1,181 @@
+use alloc::slice;
+use core::iter::Cloned;
+use p3_field::{AbstractExtensionField, AbstractField, ExtensionField, TwoAdicField};
+use p3_interpolation;
+use p3_matrix::{
+    dense::{RowMajorMatrix, RowMajorMatrixView},
+    Matrix, MatrixGet, MatrixRowSlices, MatrixRows,
+};
+use p3_util::log2_strict_usize;
+
+pub trait PublicValues<F, E>: MatrixRowSlices<F> + MatrixGet<F>
+where
+    F: TwoAdicField,
+    E: ExtensionField<F> + TwoAdicField,
+{
+    fn interpolate(&self, zeta: E, offset: usize) -> Vec<E>
+    where
+        Self: core::marker::Sized,
+    {
+        let height = self.height();
+        let log_height = log2_strict_usize(height);
+        let g = F::two_adic_generator(log_height);
+        let shift = g.powers().nth(offset).unwrap();
+
+        p3_interpolation::interpolate_coset::<F, E, _>(self, shift, zeta)
+    }
+}
+
+impl<F, E> PublicValues<F, E> for RowMajorMatrix<F>
+where
+    F: TwoAdicField,
+    E: ExtensionField<F> + TwoAdicField,
+{
+}
+
+impl<F, E> PublicValues<F, E> for RowMajorMatrixView<'_, F>
+where
+    F: TwoAdicField,
+    E: ExtensionField<F> + TwoAdicField,
+{
+}
+
+// In the case that the public values are a vector rather than a matrix,
+// we view it as a matrix with a single row repeated as many times as desired.
+pub struct PublicRow<F>(pub Vec<F>);
+pub struct PublicRowView<'a, F>(pub &'a [F]);
+
+impl<T> Matrix<T> for PublicRow<T> {
+    fn width(&self) -> usize {
+        self.0.len()
+    }
+    fn height(&self) -> usize {
+        1
+    }
+}
+impl<T> Matrix<T> for PublicRowView<'_, T> {
+    fn width(&self) -> usize {
+        self.0.len()
+    }
+    fn height(&self) -> usize {
+        1
+    }
+}
+
+impl<T: Clone> MatrixRows<T> for PublicRow<T> {
+    type Row<'a> = Cloned<slice::Iter<'a, T>> where T: 'a, Self: 'a;
+
+    fn row(&self, _r: usize) -> Self::Row<'_> {
+        self.0.iter().cloned()
+    }
+}
+impl<T: Clone> MatrixRows<T> for PublicRowView<'_, T> {
+    type Row<'a> = Cloned<slice::Iter<'a, T>> where T: 'a, Self: 'a;
+
+    fn row(&self, _r: usize) -> Self::Row<'_> {
+        self.0.iter().cloned()
+    }
+}
+
+impl<T: Clone> MatrixRowSlices<T> for PublicRow<T> {
+    fn row_slice(&self, _r: usize) -> &[T] {
+        self.0.iter().as_slice()
+    }
+}
+impl<T: Clone> MatrixRowSlices<T> for PublicRowView<'_, T> {
+    fn row_slice(&self, _r: usize) -> &[T] {
+        self.0.iter().as_slice()
+    }
+}
+
+impl<T: Clone> MatrixGet<T> for PublicRow<T> {
+    fn get(&self, _r: usize, c: usize) -> T {
+        self.0[c].clone()
+    }
+}
+impl<T: Clone> MatrixGet<T> for PublicRowView<'_, T> {
+    fn get(&self, _r: usize, c: usize) -> T {
+        self.0[c].clone()
+    }
+}
+
+impl<F, E> PublicValues<F, E> for PublicRow<F>
+where
+    F: TwoAdicField,
+    E: ExtensionField<F> + TwoAdicField,
+{
+    fn interpolate(&self, _zeta: E, _offset: usize) -> Vec<E> {
+        self.0.iter().map(|v| E::from_base(v.clone())).collect()
+    }
+}
+impl<F, E> PublicValues<F, E> for PublicRowView<'_, F>
+where
+    F: TwoAdicField,
+    E: ExtensionField<F> + TwoAdicField,
+{
+    fn interpolate(&self, _zeta: E, _offset: usize) -> Vec<E> {
+        self.0.iter().map(|v| E::from_base(v.clone())).collect()
+    }
+}
+
+pub enum ValidaPublicValues<F> {
+    PublicTrace(RowMajorMatrix<F>),
+    PublicVector(PublicRow<F>),
+}
+
+impl<F> Matrix<F> for ValidaPublicValues<F> {
+    fn width(&self) -> usize {
+        match self {
+            ValidaPublicValues::PublicTrace(mat) => mat.width(),
+            ValidaPublicValues::PublicVector(row) => row.width(),
+        }
+    }
+    fn height(&self) -> usize {
+        match self {
+            ValidaPublicValues::PublicTrace(mat) => mat.height(),
+            ValidaPublicValues::PublicVector(row) => row.height(),
+        }
+    }
+}
+
+impl<F: Clone> MatrixRows<F> for ValidaPublicValues<F> {
+    type Row<'a> = Cloned<slice::Iter<'a, F>> where F: 'a, Self: 'a;
+
+    fn row(&self, r: usize) -> Self::Row<'_> {
+        match self {
+            ValidaPublicValues::PublicTrace(mat) => mat.row(r),
+            ValidaPublicValues::PublicVector(row) => row.row(r),
+        }
+    }
+}
+
+impl<F: Clone> MatrixGet<F> for ValidaPublicValues<F> {
+    fn get(&self, r: usize, c: usize) -> F {
+        match self {
+            ValidaPublicValues::PublicTrace(mat) => mat.get(r, c),
+            ValidaPublicValues::PublicVector(row) => row.get(r, c),
+        }
+    }
+}
+
+impl<F: Clone> MatrixRowSlices<F> for ValidaPublicValues<F> {
+    fn row_slice(&self, r: usize) -> &[F] {
+        match self {
+            ValidaPublicValues::PublicTrace(mat) => mat.row_slice(r),
+            ValidaPublicValues::PublicVector(row) => row.row_slice(r),
+        }
+    }
+}
+
+impl<F, E> PublicValues<F, E> for ValidaPublicValues<F>
+where
+    F: TwoAdicField,
+    E: ExtensionField<F> + TwoAdicField,
+{
+    fn interpolate(&self, zeta: E, offset: usize) -> Vec<E> {
+        match self {
+            ValidaPublicValues::PublicTrace(mat) => mat.interpolate(zeta, offset),
+            ValidaPublicValues::PublicVector(row) => row.interpolate(zeta, offset),
+        }
+    }
+}

--- a/machine/src/symbolic/symbolic_builder.rs
+++ b/machine/src/symbolic/symbolic_builder.rs
@@ -1,10 +1,9 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::config::StarkConfig;
 use crate::{Machine, ValidaAirBuilder};
-use p3_air::ExtensionBuilder;
 use p3_air::{Air, AirBuilder, PairBuilder, PermutationAirBuilder};
+use p3_air::{AirBuilderWithPublicValues, ExtensionBuilder};
 use p3_field::AbstractExtensionField;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_ceil_usize;
@@ -59,6 +58,7 @@ pub struct SymbolicAirBuilder<'a, M: Machine<SC::Val>, SC: StarkConfig> {
     preprocessed: RowMajorMatrix<SymbolicVariable<SC::Val>>,
     main: RowMajorMatrix<SymbolicVariable<SC::Val>>,
     permutation: RowMajorMatrix<SymbolicVariable<SC::Challenge>>,
+    public_values: RowMajorMatrix<SymbolicVariable<SC::Val>>,
     constraints: Vec<SymbolicExpression<SC::Val>>,
 }
 
@@ -70,6 +70,7 @@ impl<'a, M: Machine<SC::Val>, SC: StarkConfig> SymbolicAirBuilder<'a, M, SC> {
             preprocessed: SymbolicVariable::window(Trace::Preprocessed, width),
             main: SymbolicVariable::window(Trace::Main, width),
             permutation: SymbolicVariable::window(Trace::Permutation, width),
+            public_values: SymbolicVariable::window(Trace::Public, width),
             constraints: vec![],
         }
     }
@@ -150,5 +151,13 @@ impl<'a, M: Machine<SC::Val>, SC: StarkConfig> ValidaAirBuilder for SymbolicAirB
 
     fn machine(&self) -> &Self::Machine {
         self.machine
+    }
+}
+
+impl<'a, M: Machine<SC::Val>, SC: StarkConfig> AirBuilderWithPublicValues
+    for SymbolicAirBuilder<'a, M, SC>
+{
+    fn public_values(&self) -> Self::M {
+        self.public_values.clone()
     }
 }

--- a/machine/src/symbolic/symbolic_expression.rs
+++ b/machine/src/symbolic/symbolic_expression.rs
@@ -40,7 +40,7 @@ impl<F: Field> SymbolicExpression<F> {
     /// Returns the multiple of `n` (the trace length) in this expression's degree.
     pub(crate) fn degree_multiple(&self) -> usize {
         match self {
-            SymbolicExpression::Variable(_) => 1,
+            SymbolicExpression::Variable(v) => v.degree_multiple(),
             SymbolicExpression::IsFirstRow => 1,
             SymbolicExpression::IsLastRow => 1,
             SymbolicExpression::IsTransition => 0,

--- a/machine/src/symbolic/symbolic_variable.rs
+++ b/machine/src/symbolic/symbolic_variable.rs
@@ -11,6 +11,7 @@ pub enum Trace {
     Preprocessed,
     Main,
     Permutation,
+    Public,
 }
 
 /// A variable within the evaluation window, i.e. a column in either the local or next row.
@@ -44,6 +45,15 @@ impl<F: Field> SymbolicVariable<F> {
             is_next: self.is_next,
             column: self.column,
             _phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn degree_multiple(&self) -> usize {
+        match self.trace {
+            Trace::Preprocessed => 1,
+            Trace::Main => 1,
+            Trace::Permutation => 1,
+            Trace::Public => 0,
         }
     }
 }

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use valida_machine::MEMORY_CELL_BYTES;
+use valida_machine::{ValidaPublicValues, MEMORY_CELL_BYTES};
 
 use crate::alloc::string::ToString;
 use crate::columns::{MemoryCols, MEM_COL_MAP, NUM_MEM_COLS};
@@ -16,6 +16,7 @@ use p3_field::{AbstractField, Field, PrimeField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use valida_bus::MachineWithMemBus;
+use valida_machine::PublicRow;
 use valida_machine::StarkConfig;
 use valida_machine::{Chip, Interaction, Machine, Word};
 use valida_util::batch_multiplicative_inverse_allowing_zero;
@@ -140,6 +141,8 @@ where
     M: MachineWithMemBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let mut ops = self
             .operations

--- a/native_field/src/lib.rs
+++ b/native_field/src/lib.rs
@@ -8,7 +8,9 @@ use columns::{NativeFieldCols, COL_MAP, NUM_NATIVE_FIELD_COLS};
 use core::mem::transmute;
 use valida_bus::{MachineWithGeneralBus, MachineWithRangeBus8};
 use valida_cpu::MachineWithCpuChip;
-use valida_machine::{instructions, Chip, Instruction, Interaction, Operands, Word};
+use valida_machine::{
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, ValidaPublicValues, Word,
+};
 use valida_opcodes::{ADD, MUL, SUB};
 use valida_range::MachineWithRangeChip;
 use valida_util::pad_to_power_of_two;
@@ -38,6 +40,8 @@ where
     M: MachineWithGeneralBus<SC::Val> + MachineWithRangeBus8<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let rows = self
             .operations

--- a/output/src/lib.rs
+++ b/output/src/lib.rs
@@ -4,7 +4,8 @@ use core::mem::transmute;
 use valida_bus::MachineWithGeneralBus;
 use valida_cpu::MachineWithCpuChip;
 use valida_machine::{
-    instructions, Chip, Instruction, Interaction, Operands, CPU_MEMORY_CHANNELS, MEMORY_CELL_BYTES,
+    instructions, Chip, Instruction, Interaction, Operands, PublicRow, ValidaPublicValues,
+    CPU_MEMORY_CHANNELS, MEMORY_CELL_BYTES,
 };
 use valida_opcodes::WRITE;
 
@@ -34,6 +35,8 @@ where
     M: MachineWithGeneralBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let table_len = self.values.len() as u32;
         let mut rows = self
@@ -94,6 +97,11 @@ where
         let mut values = rows.concat();
         pad_to_power_of_two::<NUM_OUTPUT_COLS, SC::Val>(&mut values);
         RowMajorMatrix::new(values, NUM_OUTPUT_COLS)
+    }
+
+    fn generate_public_values(&self) -> Option<Self::Public> {
+        //TODO: This should give the output vector, without clock values
+        None
     }
 
     //fn local_sends(&self) -> Vec<Interaction<SC::Val>> {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -2,11 +2,15 @@
 
 extern crate alloc;
 
+use core::mem::transmute;
+
 use crate::columns::NUM_PROGRAM_COLS;
 use alloc::vec;
 use alloc::vec::Vec;
+use columns::{ProgramPreprocessedCols, NUM_PREPROCESSED_COLS};
+use p3_air::BaseAir;
 use valida_bus::MachineWithProgramBus;
-use valida_machine::{Chip, Interaction, Machine, ProgramROM};
+use valida_machine::{Chip, Interaction, Machine, ProgramROM, ValidaPublicValues};
 use valida_util::pad_to_power_of_two;
 
 use p3_field::{AbstractField, Field};
@@ -35,6 +39,8 @@ where
     M: MachineWithProgramBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let mut values = self
             .counts

--- a/range/src/lib.rs
+++ b/range/src/lib.rs
@@ -8,13 +8,13 @@ use alloc::vec::Vec;
 use columns::{RangeCols, NUM_RANGE_COLS, RANGE_COL_MAP};
 use core::mem::transmute;
 use valida_bus::MachineWithRangeBus8;
-use valida_machine::Interaction;
 use valida_machine::{Chip, Machine, Word};
+use valida_machine::{Interaction, ValidaPublicValues};
 
 use p3_air::VirtualPairCol;
 use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
-use valida_machine::StarkConfig;
+use valida_machine::{PublicRow, StarkConfig};
 
 pub mod columns;
 pub mod stark;
@@ -29,6 +29,8 @@ where
     M: MachineWithRangeBus8<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let mut rows = vec![[SC::Val::zero(); NUM_RANGE_COLS]; MAX as usize];
         for (n, row) in rows.iter_mut().enumerate() {

--- a/static_data/src/lib.rs
+++ b/static_data/src/lib.rs
@@ -11,7 +11,7 @@ use p3_air::VirtualPairCol;
 use p3_field::{AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use valida_bus::MachineWithMemBus;
-use valida_machine::{Chip, Interaction, StarkConfig, Word};
+use valida_machine::{Chip, Interaction, StarkConfig, ValidaPublicValues, Word};
 use valida_memory::MachineWithMemoryChip;
 
 pub mod columns;
@@ -57,6 +57,8 @@ where
     M: MachineWithMemBus<SC::Val>,
     SC: StarkConfig,
 {
+    type Public = ValidaPublicValues<SC::Val>;
+
     fn generate_trace(&self, _machine: &M) -> RowMajorMatrix<SC::Val> {
         let mut rows = self
             .cells
@@ -76,6 +78,11 @@ where
             SC::Val::zero(),
         );
         RowMajorMatrix::new(rows, NUM_STATIC_DATA_COLS)
+    }
+
+    //TODO: fill this in with the static data values
+    fn generate_public_values(&self) -> Option<Self::Public> {
+        None
     }
 
     fn global_sends(&self, machine: &M) -> Vec<Interaction<SC::Val>> {


### PR DESCRIPTION
This PR addresses #155 by adding public values to the definition of the `Chip` trait. The public values are considered as a separate trace, similarly to how preprocessed traces are handled. However, whereas for the preprocessed trace, the indexer commits to trace matrix and the prover provides opening proofs for queries, the verifier computes its own queries against the public trace.

When implementing `Air<_, .., AB>` when `AB: AirBuilderWithPublicValues`, we are allowed to address rows of the public trace as with the ordinary trace and preprocessed trace when computing the constraints. The verifier performs polynomial interpolation of the public trace table (which should be short!) to obtain query values corresponding to the public trace columns, and uses these values when testing consistency between the quotient polynomial, the constraint polynomial, and the trace tables. 

In order to accommodate situations when the public trace is better thought of as a vector (i.e. we have a series of public values that is not indexed by row of the main trace), we implement the `PublicValues` trait for `PublicRow`, a wrapper type around an ordinary vector. This treats the `PublicRow` as a matrix with the same row repeated the appropriate number of times. 

The implementations of public values for the relevant Valida chips (namely: `ProgramROM`, `StaticData`, and `Output`) are placeholders; they will be filled in in a future PR. 