### PR TITLE
feat:avoid unchecked overflow

### DIFF
--- a/alu_u32/src/add/mod.rs
+++ b/alu_u32/src/add/mod.rs
@@ -103,15 +103,15 @@ impl Add32Chip {
 
                 let mut carry_1 = 0;
                 let mut carry_2 = 0;
-                if b[3] as u32 + c[3] as u32 > 255 {
+                if b[3].wrapping_add(c[3]) as u32  > 255 {
                     carry_1 = 1;
                     cols.carry[0] = F::one();
                 }
-                if b[2] as u32 + c[2] as u32 + carry_1 > 255 {
+                if (b[2].wrapping_add(c[2]) as u32).wrapping_add(carry_1) as u32 > 255 {
                     carry_2 = 1;
                     cols.carry[1] = F::one();
                 }
-                if b[1] as u32 + c[1] as u32 + carry_2 > 255 {
+                if (b[1].wrapping_add(c[1]) as u32).wrapping_add(carry_2) as u32 > 255 {
                     cols.carry[2] = F::one();
                 }
                 cols.is_real = F::one();
@@ -140,8 +140,8 @@ where
         let clk = state.cpu().clock;
         let pc = state.cpu().pc;
         let mut imm: Option<Word<u8>> = None;
-        let read_addr_1 = (state.cpu().fp as i32 + ops.b()) as u32;
-        let write_addr = (state.cpu().fp as i32 + ops.a()) as u32;
+        let read_addr_1 = ((state.cpu().fp as i32).wrapping_add(ops.b())) as u32;
+        let write_addr = ((state.cpu().fp as i32).wrapping_add(ops.a())) as u32;
         let b = state
             .mem_mut()
             .read(clk, read_addr_1, true, pc, opcode, 0, "");
@@ -150,7 +150,7 @@ where
             imm = Some(c);
             c
         } else {
-            let read_addr_2 = (state.cpu().fp as i32 + ops.c()) as u32;
+            let read_addr_2 = ((state.cpu().fp as i32).wrapping_add(ops.c())) as u32;
             state
                 .mem_mut()
                 .read(clk, read_addr_2, true, pc, opcode, 1, "")

--- a/machine/src/core.rs
+++ b/machine/src/core.rs
@@ -111,7 +111,7 @@ impl Add for Word<u8> {
     fn add(self, other: Self) -> Self {
         let b: u32 = self.into();
         let c: u32 = other.into();
-        let res = (b as u64 + c as u64) as u32;
+        let res=b.wrapping_add(c);
         res.into()
     }
 }
@@ -121,7 +121,7 @@ impl Sub for Word<u8> {
     fn sub(self, other: Self) -> Self {
         let b: u32 = self.into();
         let c: u32 = other.into();
-        let res = b - c;
+        let res = b.wrapping_sub(c);
         res.into()
     }
 }


### PR DESCRIPTION
Ref #79 

The following files have been corrected so far:

1. In machine/src/core.rs:
a. In the implementation of Add:add for Word<u8>, on line 57
b. In the implementation of Sub::sub for Word<u8>, on line 67
2. In alu_u32/src/add/mod.rs:
a. In the implementation of Add32Chip::op_to_row:
i. The addition on line 108
ii. The first addition on line 109
iii. The second addition on line 109
iv. The first addition on line 113
v. The second addition on line 113
b. In the implementation of Instruction<M>::execute for Add32Instruction:
i. The addition on line 141 (computing read_addr_1)
ii. The addition on line 142 (computing write_addr_1)
iii. The addition on line 149 (computing read_addr_2)
iv. The addition on line 153 (computing a)
3. In cpu/src/lib.rs:
a. In Instruction<M>::execute for ReadAdviceInstruction:
i. The two additions on line 410
ii. The multiplication on line 410
b. In Instruction<M>::execute for WriteAdviceInstruction:
i. The first and second additions on line 436 (i.e., fp + mem_addr)
ii. The third addition on line 436 (i.e., (fp + mem_addr) + mem_buf_len)
c. In Instruction<M>::execute for Load32Instruction:
i. The addition on line 470 (computing read_addr_1)
ii. The addition on line 472 (computing write_addr)
d. In Instruction<M>::execute for Store32Instruction:
i. The addition on line 491 (computing read_addr)
ii. The addition on line 492 (computing write_addr)
e. In Instruction<M>::execute for JalInstruction:
i. The addition on line 512 (computing write_addr)
ii. The addition on line 513 (computing next_pc)
ii. The addition on line 518
f. In Instruction<M>::execute for JalvInstruction:
i. The addition on line 536 (computing write_addr)
ii. The addition on line 537 (computing next_pc)
iii. The addition on line 540 (computing read_addr)
iv. The addition on line 543 (computing read_addr)
v. The additive assignment on line 545
g. In Instruction<M>::execute for BeqInstruction:
i. The addition on line 562 (computing read_addr_1)
ii. The addition on line 570 (computing read_addr_2)
iii. The addition on line 576
h. In Instruction<M>::execute for BneInstruction:
i. The addition on line 594 (computing read_addr_1)
ii. The addition on line 602 (computing read_addr_2)
iii. The addition on line 608
i. In Instruction<M>::execute for Imm32Instruction:
i. The addition on line 624 (computing write_addr)
j. Every instance of state.cpu_mut().pc += 1;
k. In impl CpuChip:
i. On line 655 and 660, self.pc += 1;
ii. On line 668, self.clock += 1;



As I correct the other files, I'll keep updating the PR description to serve as a list of pending files.