### PR TITLE
typo-Update stark.rs

### DIFF
--- a/memory/src/stark.rs
+++ b/memory/src/stark.rs
@@ -64,7 +64,7 @@ impl MemoryChip {
         //         .assert_eq(value_next, value);
         // }
 
-        // // TODO: This disallows reading unitialized memory? Not sure that's desired, it depends on
+        // // TODO: This disallows reading uninitialized memory? Not sure that's desired, it depends on
         // // how we implement continuations. If we end up defaulting to zero, then we should replace
         // // this with
         // //     when(is_read).when(addr_delta).assert_zero(value_next);


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `memory/src/stark.rs:67`: "unitialized" corrected to "uninitialized".

## Purpose
- Improved code accuracy and ensured professionalism by fixing the typo.
